### PR TITLE
Fix setting _p_changed for small pure-Python BTrees.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ coverage.xml
 *.egg
 dist
 .eggs/
+.dir-locals.el

--- a/BTrees/_base.py
+++ b/BTrees/_base.py
@@ -883,11 +883,16 @@ class _Tree(_Base):
                 max_size = self.max_leaf_size
             if child.size > max_size:
                 self._grow(child, index)
-        elif (grew is not None and
-              child.__class__ is self._bucket_type and
-              len(data) == 1 and
-              child._p_oid is None
-              ):
+
+        # If a BTree contains only a single bucket, BTree.__getstate__()
+        # includes the bucket's entire state, and the bucket doesn't get
+        # an oid of its own.  So if we have a single oid-less bucket that
+        # changed, it's *our* oid that should be marked as changed -- the
+        # bucket doesn't have one.
+        if (grew is not None and
+            child.__class__ is self._bucket_type and
+            len(data) == 1 and
+            child._p_oid is None):
             self._p_changed = 1
         return result
 

--- a/BTrees/tests/common.py
+++ b/BTrees/tests/common.py
@@ -1114,9 +1114,30 @@ class BTreeTests(MappingBase):
 
         t._p_jar = Jar()
         t[1] = 3
+        # reset these, setting _firstbucket triggered a change
         t._p_changed = False
         t._p_jar.registered = None
         t[2] = 4
+        self.assertTrue(t._p_changed)
+        self.assertEqual(t, t._p_jar.registered)
+
+        # Setting the same key to a different value also triggers a change
+        t._p_changed = False
+        t._p_jar.registered = None
+        t[2] = 5
+        self.assertTrue(t._p_changed)
+        self.assertEqual(t, t._p_jar.registered)
+
+        # Likewise with only a single value
+        t = self._makeOne()
+        t._p_oid = b'\0\0\0\0\0'
+        t._p_jar = Jar()
+        t[1] = 3
+        # reset these, setting _firstbucket triggered a change
+        t._p_changed = False
+        t._p_jar.registered = None
+
+        t[1] = 6
         self.assertTrue(t._p_changed)
         self.assertEqual(t, t._p_jar.registered)
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@
   See:  https://github.com/zopefoundation/BTrees/issues/9
 
 - Fix _p_changed for small pure-Python BTrees.
-  See   https://github.com/zopefoundation/BTrees/issues/10
+  See   https://github.com/zopefoundation/BTrees/issues/11
 
 
 4.1.1 (2014-12-27)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@
 - Suppress testing 64-bit values in OLBTrees on 32 bit machines.
   See:  https://github.com/zopefoundation/BTrees/issues/9
 
+- Fix _p_changed for small pure-Python BTrees.
+  See   https://github.com/zopefoundation/BTrees/issues/10
+
 
 4.1.1 (2014-12-27)
 ------------------


### PR DESCRIPTION
When working on [zopefoundation/zc.zodbdgc#1](https://github.com/zopefoundation/zc.zodbdgc/pull/1#discussion-diff-27853357), we found a bug in the pure-Python BTree implementation. An `elif` that should have been its own `if` prevented the second and subsequent additions to a BTree from setting the `_p_changed` flag, right up until the first bucket needed to split. 

This can cause data-loss for small BTrees.

This PR adds a test case and should fix the issue (the comment is copied from the C implementation).