### PR TITLE
Fix setting _p_changed when removing from small Python BTrees/TreeSets.

### DIFF
--- a/BTrees/_base.py
+++ b/BTrees/_base.py
@@ -559,6 +559,7 @@ class Set(_BucketBase):
         index = self._search(key)
         if index < 0:
             index = -index - 1
+            self._p_changed = True
             self._keys.insert(index, key)
             return True, None
         return False, None

--- a/BTrees/_base.py
+++ b/BTrees/_base.py
@@ -942,6 +942,12 @@ class _Tree(_Base):
 
         removed_first_bucket, value = child._del(key)
 
+        # See comment in _set about small trees
+        if (len(data) == 1 and
+            child.__class__ is self._bucket_type and
+            child._p_oid is None):
+            self._p_changed = True
+
         # fix up the node key, but not for the 0'th one.
         if index > 0 and child.size and key == data[index].key:
             self._p_changed = True

--- a/BTrees/tests/common.py
+++ b/BTrees/tests/common.py
@@ -1421,6 +1421,32 @@ class NormalSetTests(Base):
         self.assertTrue(t._p_changed)
         self.assertEqual(t, t._p_jar.registered)
 
+    def testAddingOneSetsChanged(self):
+        # A bug in the BTree Set Python implementation once caused
+        # adding an object not to set _p_changed
+        t = self._makeOne()
+        # Note that for the property to actually hold, we have to fake a
+        # _p_jar and _p_oid
+        t._p_oid = b'\0\0\0\0\0'
+        class Jar(object):
+            def __init__(self):
+                self._cache = self
+                self.registered = None
+
+            def mru(self, arg):
+                pass
+            def readCurrent(self, arg):
+                pass
+            def register(self, arg):
+                self.registered = arg
+
+        t._p_jar = Jar()
+        t.add(0)
+        self.assertTrue(t._p_changed)
+        self.assertEqual(t, t._p_jar.registered)
+
+        # Whether or not doing `t.add(0)` again would result in
+        # _p_changed being set depends on whether this is a TreeSet or a plain Set
 
 class ExtendedSetTests(NormalSetTests):
 

--- a/BTrees/tests/common.py
+++ b/BTrees/tests/common.py
@@ -1148,7 +1148,9 @@ class BTreeTests(MappingBase):
 
     def testRemoveInSmallMapSetsChanged(self):
         # A bug in the BTree Python implementation once caused
-        # deleting from a small btree to set _p_changed
+        # deleting from a small btree to set _p_changed.
+        # There must be at least two objects so that _firstbucket doesn't
+        # get set
         t = self._makeOne()
         # Note that for the property to actually hold, we have to fake a
         # _p_jar and _p_oid
@@ -1167,12 +1169,13 @@ class BTreeTests(MappingBase):
 
         t._p_jar = Jar()
         t[0] = 1
+        t[1] = 2
         # reset these, setting _firstbucket triggered a change
         t._p_changed = False
         t._p_jar.registered = None
 
         # now remove the second value
-        del t[0]
+        del t[1]
         self.assertTrue(t._p_changed)
         self.assertEqual(t, t._p_jar.registered)
 
@@ -1387,7 +1390,9 @@ class NormalSetTests(Base):
 
     def testRemoveInSmallSetSetsChanged(self):
         # A bug in the BTree TreeSet Python implementation once caused
-        # deleting an item in a small set to fail to set _p_changed
+        # deleting an item in a small set to fail to set _p_changed.
+        # There must be at least two objects so that _firstbucket doesn't
+        # get set
         t = self._makeOne()
         # Note that for the property to actually hold, we have to fake a
         # _p_jar and _p_oid
@@ -1406,12 +1411,13 @@ class NormalSetTests(Base):
 
         t._p_jar = Jar()
         t.add(0)
+        t.add(1)
         # reset these, setting _firstbucket triggered a change
         t._p_changed = False
         t._p_jar.registered = None
 
         # now remove the second value
-        t.remove(0)
+        t.remove(1)
         self.assertTrue(t._p_changed)
         self.assertEqual(t, t._p_jar.registered)
 

--- a/BTrees/tests/common.py
+++ b/BTrees/tests/common.py
@@ -1146,6 +1146,37 @@ class BTreeTests(MappingBase):
         self.assertTrue(t._p_changed)
         self.assertEqual(t, t._p_jar.registered)
 
+    def testRemoveInSmallMapSetsChanged(self):
+        # A bug in the BTree Python implementation once caused
+        # deleting from a small btree to set _p_changed
+        t = self._makeOne()
+        # Note that for the property to actually hold, we have to fake a
+        # _p_jar and _p_oid
+        t._p_oid = b'\0\0\0\0\0'
+        class Jar(object):
+            def __init__(self):
+                self._cache = self
+                self.registered = None
+
+            def mru(self, arg):
+                pass
+            def readCurrent(self, arg):
+                pass
+            def register(self, arg):
+                self.registered = arg
+
+        t._p_jar = Jar()
+        t[0] = 1
+        # reset these, setting _firstbucket triggered a change
+        t._p_changed = False
+        t._p_jar.registered = None
+
+        # now remove the second value
+        del t[0]
+        self.assertTrue(t._p_changed)
+        self.assertEqual(t, t._p_jar.registered)
+
+
 class NormalSetTests(Base):
     # Test common to all set types
 
@@ -1353,6 +1384,37 @@ class NormalSetTests(Base):
             except StopIteration:
                 pass
             self.assertEqual(x, keys)
+
+    def testRemoveInSmallSetSetsChanged(self):
+        # A bug in the BTree TreeSet Python implementation once caused
+        # deleting an item in a small set to fail to set _p_changed
+        t = self._makeOne()
+        # Note that for the property to actually hold, we have to fake a
+        # _p_jar and _p_oid
+        t._p_oid = b'\0\0\0\0\0'
+        class Jar(object):
+            def __init__(self):
+                self._cache = self
+                self.registered = None
+
+            def mru(self, arg):
+                pass
+            def readCurrent(self, arg):
+                pass
+            def register(self, arg):
+                self.registered = arg
+
+        t._p_jar = Jar()
+        t.add(0)
+        # reset these, setting _firstbucket triggered a change
+        t._p_changed = False
+        t._p_jar.registered = None
+
+        # now remove the second value
+        t.remove(0)
+        self.assertTrue(t._p_changed)
+        self.assertEqual(t, t._p_jar.registered)
+
 
 class ExtendedSetTests(NormalSetTests):
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@
 4.1.3 (unreleased)
 ------------------
 
-- TBD
+- Fix _p_changed when removing items from small pure-Python
+  BTrees/TreeSets. See:
+  https://github.com/zopefoundation/BTrees/issues/13
 
 
 4.1.2 (2015-04-07)
@@ -13,8 +15,9 @@
 - Suppress testing 64-bit values in OLBTrees on 32 bit machines.
   See:  https://github.com/zopefoundation/BTrees/issues/9
 
-- Fix _p_changed for small pure-Python BTrees.
-  See   https://github.com/zopefoundation/BTrees/issues/11
+- Fix _p_changed when adding items to small pure-Python
+  BTrees/TreeSets. See:
+  https://github.com/zopefoundation/BTrees/issues/11
 
 
 4.1.1 (2014-12-27)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 ------------------
 
 - Fix _p_changed when removing items from small pure-Python
-  BTrees/TreeSets. See:
+  BTrees/TreeSets and when adding to Sets. See:
   https://github.com/zopefoundation/BTrees/issues/13
 
 


### PR DESCRIPTION
Sadly, the fix for #11 was incomplete (sorry) and failed to handle removal, which bit us testing our application under PyPy. This PR handles removal and adds test cases for it.

Example test failures before the fix:
```
======================================================================
FAIL: testRemoveInSmallMapSetsChanged (BTrees.tests.test_OOBTree.OOBTreePyTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "//BTrees/BTrees/tests/common.py", line 1179, in testRemoveInSmallMapSetsChanged
    self.assertTrue(t._p_changed)
AssertionError: False is not true

======================================================================
FAIL: testRemoveInSmallSetSetsChanged (BTrees.tests.test_OOBTree.OOTreeSetPyTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "//BTrees/BTrees/tests/common.py", line 1421, in testRemoveInSmallSetSetsChanged
    self.assertTrue(t._p_changed)
AssertionError: False is not true

----------------------------------------------------------------------
```

Twice, out of many test runs, I saw the following test failure for Python2.7. I'm pretty sure it's unrelated:
```
======================================================================
ERROR: test_LP294788 (BTrees.tests.testBTrees.BugFixes)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "//BTrees/BTrees/tests/testBTrees.py", line 355, in test_LP294788
    id = trandom.choice(list(ids.keys()))
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/random.py", line 275, in choice
    return seq[int(self.random() * len(seq))]  # raises IndexError if seq is empty
IndexError: list index out of range

----------------------------------------------------------------------
```