### PR TITLE
Human-readable __repr__ for pure-Python Bucket and Set objects.

### DIFF
--- a/BTrees/_base.py
+++ b/BTrees/_base.py
@@ -155,6 +155,12 @@ class _BucketBase(_Base):
 
     has_key = __contains__
 
+    def _repr_helper(self, items):
+        type_self = type(self)
+        mod = type_self.__module__
+        name = type_self.__name__
+        name = name[:-2] if name.endswith("Py") else name
+        return "%s.%s(%r)" % (mod, name, items)
 
 class _SetIteration(object):
 
@@ -517,6 +523,8 @@ class Bucket(_BucketBase):
         result._next = b_old._next
         return result.__getstate__()
 
+    def __repr__(self):
+        return self._repr_helper(self.items())
 
 class Set(_BucketBase):
 
@@ -711,6 +719,8 @@ class Set(_BucketBase):
         result._next = b_old._next
         return result.__getstate__()
 
+    def __repr__(self):
+        return self._repr_helper(self._keys)
 
 class _TreeItem(object):
 
@@ -1066,6 +1076,10 @@ class _Tree(_Base):
         return ((
             self._bucket_type()._p_resolveConflict(s_old, s_com, s_new), ), )
 
+    def __repr__(self):
+        r = super(_Tree, self).__repr__()
+        r = r.replace('Py', '')
+        return r
 
 def _get_simple_btree_bucket_state(state):
     if state is None:

--- a/BTrees/tests/common.py
+++ b/BTrees/tests/common.py
@@ -228,6 +228,14 @@ class MappingBase(Base):
         # Make sure the repr is **not* 10000 bytes long for a shrort bucket.
         # (the buffer must be terminated when copied).
         self.assertTrue(len(r) < 10000)
+        # Make sure the repr is human readable if it's a bucket
+        if 'Bucket' in r:
+            self.assertTrue(r.startswith("BTrees"))
+            self.assertTrue(r.endswith(repr(t.items()) + ')'), r)
+        else:
+            self.assertEqual(r[:8], '<BTrees.')
+        # Make sure it's the same between Python and C
+        self.assertTrue('Py' not in r)
 
     def testRepr(self):
         # test the repr because buckets have a complex repr implementation
@@ -1186,6 +1194,23 @@ class NormalSetTests(Base):
     def _populate(self, t, l):
         # Make some data
         t.update(range(l))
+
+    def testShortRepr(self):
+        t = self._makeOne()
+        for i in range(5):
+            t.add(i)
+        r = repr(t)
+        # Make sure the repr is **not* 10000 bytes long for a shrort bucket.
+        # (the buffer must be terminated when copied).
+        self.assertTrue(len(r) < 10000)
+        # Make sure the repr is human readable, unless it's a tree
+        if 'TreeSet' not in r:
+            self.assertTrue(r.endswith("Set(%r)" % t.keys()))
+        else:
+            self.assertEqual(r[:7], '<BTrees', r)
+        # Make sure it's the same between Python and C
+        self.assertTrue('Py' not in r)
+
 
     def testInsertReturnsValue(self):
         t = self._makeOne()

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@
 4.1.4 (unreleased)
 ------------------
 
-- TBD
+- Pure-Python Bucket and Set objects have a human readable
+  ``__repr__`` like the C versions.
 
 4.1.3 (2015-05-19)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 4.1.4 (unreleased)
 ------------------
 
-- Pure-Python Bucket and Set objects have a human readable
+- Ensure that pure-Python Bucket and Set objects have a human readable
   ``__repr__`` like the C versions.
 
 4.1.3 (2015-05-19)


### PR DESCRIPTION
This greatly assists debugging, and matches the C implementation.

It also makes doctests easier to run on both pure-Python and PyPy, e.g., zope.catalog.