### PR TITLE
Ensure that we don't overlook errors in first 'PyObject_RichCompareBool' call

### DIFF
--- a/BTrees/_compat.h
+++ b/BTrees/_compat.h
@@ -27,9 +27,25 @@
 #define TEXT_FROM_STRING PyUnicode_FromString
 #define TEXT_FORMAT PyUnicode_Format
 
-#define COMPARE(lhs, rhs) \
-    PyObject_RichCompareBool((lhs), (rhs), Py_LT) > 0 ? -1 : \
-    (PyObject_RichCompareBool((lhs), (rhs), Py_EQ) > 0 ? 0 : 1)
+/* Emulate Python2's __cmp__,  wrapping PyObject_RichCompareBool(),
+ * Return -2/-3 for errors, -1 for lhs<rhs, 0 for lhs==rhs, 1 for lhs>rhs.
+ */
+static inline
+int __compare(PyObject *lhs, PyObject *rhs) {
+    int less, equal;
+
+    less = PyObject_RichCompareBool(lhs, rhs, Py_LT);
+    if ( less == -1 ) {
+        return -2;
+    }
+    equal = PyObject_RichCompareBool(lhs, rhs, Py_EQ);
+    if ( equal == -1 ) {
+        return -3;
+    }
+    return less ? -1 : (equal ? 0 : 1);
+}
+
+#define COMPARE(lhs, rhs) __compare((lhs), (rhs))
 
 
 #else

--- a/BTrees/_compat.h
+++ b/BTrees/_compat.h
@@ -38,11 +38,14 @@ int __compare(PyObject *lhs, PyObject *rhs) {
     if ( less == -1 ) {
         return -2;
     }
+    if (less) {
+        return -1;
+    }
     equal = PyObject_RichCompareBool(lhs, rhs, Py_EQ);
     if ( equal == -1 ) {
         return -3;
     }
-    return less ? -1 : (equal ? 0 : 1);
+    return equal ? 0 : 1;
 }
 
 #define COMPARE(lhs, rhs) __compare((lhs), (rhs))


### PR DESCRIPTION
Python 3.5 turns such cases into SystemErrors.

See: https://bugs.python.org/issue23571

Fixes #15.