### PR TITLE
Use 'sys.maxsize' to detect real 32-bit Python.

### DIFF
--- a/BTrees/tests/common.py
+++ b/BTrees/tests/common.py
@@ -12,7 +12,7 @@
 #
 ##############################################################################
 
-import platform
+import sys
 
 
 def _skip_wo_ZODB(test_method): #pragma NO COVER
@@ -36,7 +36,7 @@ def _skip_under_Py3k(test_method): #pragma NO COVER
         return test_method
 
 def _skip_on_32_bits(test_method): #pragma NO COVER
-    if platform.architecture()[0] == '32bit':
+    if sys.maxsize == 2**32:
         def _dummy(*args):
             pass
         return _dummy


### PR DESCRIPTION
Works around the fact that `platform.architecture()` reports size of *pointers*, rather than size of *longs*, which matters on Win64.

Closes: #32.