### PR TITLE
(Attempt to) fix Overflow in tests on Win64.

### DIFF
--- a/BTrees/BTreeModuleTemplate.c
+++ b/BTrees/BTreeModuleTemplate.c
@@ -84,13 +84,23 @@ longlong_check(PyObject *ob)
         return 1;
 
     if (PyLong_Check(ob)) {
+#if PY_VERSION_HEX < 0x02070000
         /* check magnitude */
         PY_LONG_LONG val = PyLong_AsLongLong(ob);
 
         if (val == -1 && PyErr_Occurred())
-            return 0;
+            goto overflow;
+#else
+        int overflow;
+        (void)PyLong_AsLongLongAndOverflow(ob, &overflow);
+        if (overflow)
+            goto overflow;
+#endif
         return 1;
     }
+    return 0;
+overflow:
+    PyErr_SetString(PyExc_ValueError, "long integer out of range");
     return 0;
 }
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@
 4.3.0 (TBD)
 -----------
 
+- Fix unexpected ``OverflowError`` when passing 64bit values to long
+  keys / values on Win64.  See:
+  https://github.com/zopefoundation/BTrees/issues/32
+
 - When testing ``PURE_PYTHON`` environments under ``tox``, avoid poisoning
   the user's global wheel cache.
 


### PR DESCRIPTION
See: https://github.com/zopefoundation/BTrees/issues/32.