### PR TITLE
build BTrees for 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
           env: TERRYFY_PYTHON='homebrew 2'
         - os: osx
           language: generic
+          env: TERRYFY_PYTHON='macpython 3.4'
+        - os: osx
+          language: generic
           env: TERRYFY_PYTHON='homebrew 3'
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git clone https://github.com/MacPython/terryfy; fi


### PR DESCRIPTION
This adds python 3.4 on mac os x to the build matrix. 