### PR TITLE
Add requirements file for RTD.

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,0 +1,4 @@
+pip>=8.1.2
+setuptools>=23.0.0
+repoze.sphinx.autointerface
+sphinx_rtd_theme


### PR DESCRIPTION
This allows BTrees docs to build and be published on http://btrees.readthedocs.io. This is useful for intersphinx references. (The docs on pythonhosted.org/BTrees haven't been built since 2012 or so and don't have intersphinx data.)