### PR TITLE
Point the doc link to the rendered site.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,5 +12,5 @@ a modified BTree data structure.  The trees are optimized for use inside
 ZODB's "optimistic concurrency" paradigm, and include explicit resolution
 of conflicts detected by that mechannism.
 
-Please see the Sphinx documentation (``docs/index.rst``) for further
+Please see `the Sphinx documentation <http://btrees.readthedocs.io/>`_ for further
 information.


### PR DESCRIPTION
Mostly for PyPI's benefit.

