### PR TITLE
Proposed fix for issue #4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,6 @@ setup(name='BTrees',
       include_package_data=True,
       zip_safe=False,
       ext_modules = ext_modules,
-      setup_requires=['persistent'],
       extras_require = {
         'test': TESTS_REQUIRE,
         'ZODB': ['ZODB'],


### PR DESCRIPTION
Removed setup_requires = ['persistent']

The issue: #48 

Since the persistent module is not actually needed at setup time- it is only needed in install_requires, where it is already specified.

When it is present in setup_requires, it breaks configurations that use local repositories
like Artifactory. There are no clean workarounds that I have been able to find.


Since the persistent module is not actually needed at setup time- it is only needed in install_requires, where it is already specified.

When it is present in setup_requires, it breaks configurations that use local repositories
like Artifactory. There are no clean workarounds that I have been able to find.

I tested this and it works fine. Perhaps this was done by mistake?

I'd appreciate if this could be merged into a 4.3.0a or 4.3.1 release on PyPi so I can actually benefit from this being fixed. As of now I am left with clunky workarounds and can't use requirements.txt
I tested this and it works fine. Perhaps this was done by mistake?

I'd appreciate if this could be merged into a 4.3.0a or 4.3.1 release on PyPi so I can actually benefit from this being fixed. As of now I am left with clunky workarounds and can't use requirements.txt