### PR TITLE
Get 'py35-pure' tox environment passing.

### DIFF
--- a/BTrees/IFBTree.py
+++ b/BTrees/IFBTree.py
@@ -106,7 +106,7 @@ weightedIntersectionPy = _set_operation(_weightedIntersection, IFSetPy)
 
 try:
     from ._IFBTree import IFBucket
-except ImportError: #pragma NO COVER w/ C extensions
+except (ImportError, AttributeError): #pragma NO COVER w/ C extensions
     IFBucket = IFBucketPy
     IFSet = IFSetPy
     IFBTree = IFBTreePy

--- a/BTrees/IIBTree.py
+++ b/BTrees/IIBTree.py
@@ -107,7 +107,7 @@ weightedIntersectionPy = _set_operation(_weightedIntersection, IISetPy)
 
 try:
     from ._IIBTree import IIBucket
-except ImportError: #pragma NO COVER w/ C extensions
+except (ImportError, AttributeError): #pragma NO COVER w/ C extensions
     IIBucket = IIBucketPy
     IISet = IISetPy
     IIBTree = IIBTreePy

--- a/BTrees/IOBTree.py
+++ b/BTrees/IOBTree.py
@@ -89,7 +89,7 @@ multiunionPy = _set_operation(_multiunion, IOSetPy)
 
 try:
     from ._IOBTree import IOBucket
-except ImportError: #pragma NO COVER w/ C extensions
+except (ImportError, AttributeError): #pragma NO COVER w/ C extensions
     IOBucket = IOBucketPy
     IOSet = IOSetPy
     IOBTree = IOBTreePy

--- a/BTrees/LFBTree.py
+++ b/BTrees/LFBTree.py
@@ -107,7 +107,7 @@ weightedIntersectionPy = _set_operation(_weightedIntersection, LFSetPy)
 
 try:
     from ._LFBTree import LFBucket
-except ImportError: #pragma NO COVER w/ C extensions
+except (ImportError, AttributeError): #pragma NO COVER w/ C extensions
     LFBucket = LFBucketPy
     LFSet = LFSetPy
     LFBTree = LFBTreePy

--- a/BTrees/LLBTree.py
+++ b/BTrees/LLBTree.py
@@ -107,7 +107,7 @@ weightedIntersectionPy = _set_operation(_weightedIntersection, LLSetPy)
 
 try:
     from ._LLBTree import LLBucket
-except ImportError: #pragma NO COVER w/ C extensions
+except (ImportError, AttributeError): #pragma NO COVER w/ C extensions
     LLBucket = LLBucketPy
     LLSet = LLSetPy
     LLBTree = LLBTreePy

--- a/BTrees/LOBTree.py
+++ b/BTrees/LOBTree.py
@@ -90,7 +90,7 @@ multiunionPy = _set_operation(_multiunion, LOSetPy)
 
 try:
     from ._LOBTree import LOBucket
-except ImportError: #pragma NO COVER w/ C extensions
+except (ImportError, AttributeError): #pragma NO COVER w/ C extensions
     LOBucket = LOBucketPy
     LOSet = LOSetPy
     LOBTree = LOBTreePy

--- a/BTrees/OIBTree.py
+++ b/BTrees/OIBTree.py
@@ -104,7 +104,7 @@ weightedIntersectionPy = _set_operation(_weightedIntersection, OISetPy)
 
 try:
     from ._OIBTree import OIBucket
-except ImportError: #pragma NO COVER w/ C extensions
+except (ImportError, AttributeError): #pragma NO COVER w/ C extensions
     OIBucket = OIBucketPy
     OISet = OISetPy
     OIBTree = OIBTreePy

--- a/BTrees/OLBTree.py
+++ b/BTrees/OLBTree.py
@@ -105,7 +105,7 @@ weightedIntersectionPy = _set_operation(_weightedIntersection, OLSetPy)
 
 try:
     from ._OLBTree import OLBucket
-except ImportError: #pragma NO COVER w/ C extensions
+except (ImportError, AttributeError): #pragma NO COVER w/ C extensions
     OLBucket = OLBucketPy
     OLSet = OLSetPy
     OLBTree = OLBTreePy

--- a/BTrees/OOBTree.py
+++ b/BTrees/OOBTree.py
@@ -85,7 +85,7 @@ intersectionPy = _set_operation(_intersection, OOSetPy)
 
 try:
     from ._OOBTree import OOBucket
-except ImportError as e: #pragma NO COVER w/ C extensions
+except (ImportError, AttributeError): #pragma NO COVER w/ C extensions
     OOBucket = OOBucketPy
     OOSet = OOSetPy
     OOBTree = OOBTreePy

--- a/BTrees/_base.py
+++ b/BTrees/_base.py
@@ -49,7 +49,7 @@ class _Base(Persistent):
         # If the C extensions are around, we do need these methods, but
         # these classes are unlikely to be used in production anyway.
         __import__('BTrees._OOBTree')
-    except ImportError:  # pragma: no cover
+    except (ImportError, AttributeError):  # pragma: no cover
         pass
     else:
         def __reduce__(self):

--- a/BTrees/fsBTree.py
+++ b/BTrees/fsBTree.py
@@ -103,7 +103,7 @@ intersectionPy = _set_operation(_intersection, fsSetPy)
 
 try:
     from ._fsBTree import fsBucket
-except ImportError: #pragma NO COVER w/ C extensions
+except (ImportError, AttributeError): #pragma NO COVER w/ C extensions
     fsBucket = fsBucketPy
     fsSet = fsSetPy
     fsBTree = fsBTreePy


### PR DESCRIPTION
On Py3k, the conditional imports fail with an `AttributeError` when the C extensions are missing, rather than an `ImportError`.