### PR TITLE
Build and deploy manylinux builds on tagged commit

### DIFF
--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e -x
+
+# Compile wheels
+for PYBIN in /opt/python/*/bin; do
+    if [[ "${PYBIN}" == *"cp27"* ]] || \
+       [[ "${PYBIN}" == *"cp33"* ]] || \	   
+       [[ "${PYBIN}" == *"cp34"* ]] || \
+       [[ "${PYBIN}" == *"cp35"* ]] || \
+       [[ "${PYBIN}" == *"cp36"* ]]; then
+        "${PYBIN}/pip" install -e /io/
+        "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+    fi
+done
+
+# Bundle external shared libraries into the wheels
+for whl in wheelhouse/BTrees*.whl; do
+    auditwheel repair "$whl" -w /io/wheelhouse/
+done
+

--- a/.manylinux.sh
+++ b/.manylinux.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e -x
+
+docker pull $DOCKER_IMAGE
+
+docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/.manylinux-install.sh
+
+pip install twine && twine upload -u zope.wheelbuilder -p $PYPIPASSWORD wheelhouse/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,25 @@ matrix:
         - os: osx
           language: generic
           env: TERRYFY_PYTHON='macpython 3.6.0'
+        - services:
+            - docker
+          env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+          before_install:
+            - if [[ $TRAVIS_TAG ]]; then bash .manylinux.sh; fi
+            - exit 0
+        - services:
+            - docker
+          env:
+            - DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
+            - PRE_CMD=linux32
+          before_install:
+            - if [[ $TRAVIS_TAG ]]; then bash .manylinux.sh; fi
+            - exit 0
+  
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git clone https://github.com/MacPython/terryfy; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source terryfy/travis_tools.sh; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then get_python_environment $TERRYFY_PYTHON venv; fi
-    - if [[ "$TERRYFY_PYTHON" == "homebrew 3" ]]; then alias pip=`which pip3` ; fi
 install:
     - pip install -U pip setuptools
     # persistent is a setup_requires, which gets downloaded by


### PR DESCRIPTION
Relates to #66 

This PR adds manylinux1 builds. Because, this builds bails out very quickly unless the instigating commit is a tagged commit. It should have minimal impact on zopefoundations' travis queue.

