### PR TITLE
errant white space preventing some builds in manylinux

### DIFF
--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -5,7 +5,7 @@ set -e -x
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     if [[ "${PYBIN}" == *"cp27"* ]] || \
-       [[ "${PYBIN}" == *"cp33"* ]] || \	   
+       [[ "${PYBIN}" == *"cp33"* ]] || \   
        [[ "${PYBIN}" == *"cp34"* ]] || \
        [[ "${PYBIN}" == *"cp35"* ]] || \
        [[ "${PYBIN}" == *"cp36"* ]]; then


### PR DESCRIPTION
This whitespace prevented the 2.7 and 3.3 builds. attn @mgedmin 