### PR TITLE
Avoid spurious "failures" on Appveyor during releases

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ install:
   - pip install -e .[test,ZODB]
 
 build_script:
+  - python -m pip install -U pip
   - pip install wheel
   - python -W ignore setup.py -q bdist_wheel
 
@@ -33,6 +34,6 @@ artifacts:
     name: wheel
 
 deploy_script:
-  - ps: if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { pip install twine; twine upload dist/* }
+  - ps: if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { pip install twine; twine upload dist/*.whl }
 
 deploy: on

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,6 @@ artifacts:
     name: wheel
 
 deploy_script:
-  - ps: if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { pip install twine; twine upload dist/*.whl }
+  - ps: if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { pip install twine; twine upload --skip-existing dist/* }
 
 deploy: on


### PR DESCRIPTION
PowerShell interprets any stderr output from a child process as an
error.  This means warnings from pip about using
not-the-very-latest-version-how-dare-you and warnings from twine about
uploading the *.tar.gz which was probably already uploaded already and
might not be a bitwise identical copy because what even is
reproducibility cause the Appveyor builds to fail, even if the actual
binary wheels we want have been built and uploaded successfully.

*pauses to breathe*