### PR TITLE
Fix segfault on repr(OOBucket([... non-Latin-1 thingies ...]))

### DIFF
--- a/BTrees/tests/testBTreesUnicode.py
+++ b/BTrees/tests/testBTreesUnicode.py
@@ -72,5 +72,18 @@ class TestBTreesUnicode(unittest.TestCase):
             self.assertTrue(isinstance(k, str))
             self.assertEqual(self.tree[k], v)
 
+
+class TestBTreeBucketUnicode(unittest.TestCase):
+
+    def testUnicodeRepr(self):
+        # Regression test for
+        # https://github.com/zopefoundation/BTrees/issues/106
+        items = [(1, u'\uaabb')]
+        from BTrees.OOBTree import OOBucket
+        bucket = OOBucket(items)
+        self.assertEqual(repr(bucket),
+                         'BTrees.OOBTree.OOBucket(%s)' % repr(items))
+
+
 def test_suite():
-    return unittest.makeSuite(TestBTreesUnicode)
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@
   See `issue 98
   <https://github.com/zopefoundation/BTrees/issues/98>`_.
 
+- Fix segmentation fault in ``bucket_repr()``.  See
+  `issue 106 <https://github.com/zopefoundation/BTrees/issue/106>`_.
+
 
 4.5.1 (2018-08-09)
 ------------------

--- a/tox.ini
+++ b/tox.ini
@@ -7,22 +7,13 @@ envlist =
 
 [testenv]
 usedevelop = true
-deps =
-    .[test]
+extras =
+    test
 commands =
     zope-testrunner --test-path=. --auto-color --auto-progress []
-
-[testenv:py27-pure]
-basepython =
-    python2.7
 setenv =
-    PURE_PYTHON = 1
-
-[testenv:py35-pure]
-basepython =
-    python3.5
-setenv =
-    PURE_PYTHON = 1
+    PYTHONFAULTHANDLER=1
+    pure: PURE_PYTHON=1
 
 #[testenv:jython]
 #commands =
@@ -32,7 +23,6 @@ setenv =
 basepython =
     python2.7
 deps =
-    {[testenv]deps}
     ZODB
 
 [testenv:coverage]
@@ -42,7 +32,6 @@ commands =
     coverage run -m zope.testrunner --test-path=. --auto-color --auto-progress []
     coverage report --fail-under=92
 deps =
-    {[testenv]deps}
     coverage
 
 [testenv:docs]
@@ -51,5 +40,5 @@ basepython =
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
-deps =
-    .[docs]
+extras =
+    docs


### PR DESCRIPTION
Fixes #106.

The bug was in not checking the return value of PyUnicode_AsLatin1String() and passing a NULL to PyOS_snprintf().

The fix uses PyUnicode_FromFormat() and avoids all the hassle of manual encoding/sprintf/decoding and even calling repr().

I've also added a regression test and tweaked `tox.ini` to set PYTHONFAULTHANDLER=1 to make the segfault visible -- without that all you see is the test runner exiting unexpectedly with no additional output (and you have to interpret "exited with code -11" as _died from a SIGSEGV_ yourself).
