### PR TITLE
adds python 3.8 on macos to the travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,10 @@ jobs:
       os: osx
       language: generic
       env: TERRYFY_PYTHON='macpython 3.7.0'
+    - name: Python 3.8 wheels for MacOS
+      os: osx
+      language: generic
+      env: TERRYFY_PYTHON='macpython 3.8.0'
 
 before_install:
   - |


### PR DESCRIPTION
This should allow for making macos wheels for py3.8.