### PR TITLE
Fixed tox 'docs' environment

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -385,7 +385,7 @@ Example
 .. doctest::
    :options: +SKIP
 
-   >>> from BTrees.IIBTree import *
+   >>> from BTrees.IIBTree import IISet
    >>> s = IISet(range(10))
    >>> list(s)
    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -410,7 +410,7 @@ of the keys.  Example
 
 .. doctest::
 
-   >>> from BTrees.IIBTree import *
+   >>> from BTrees.IIBTree import IISet
    >>> s = IISet(range(10))
    >>> for i in list(s.keys()):  # this is well defined
    ...     print(i)


### PR DESCRIPTION
Without this patch running `tox -e docs` would produce this:

```
Sphinx v2.4.4 en cours d'exécution
chargement de l'environnement pickled... fait
construction en cours [mo]:cibles pour les fichiers po 0 qui sont périmées
construction [doctest]:cibles pour les fichiers sources 4 qui sont périmées
mise-à-jour de l'environnement :0 ajouté, 0 modifié, 0 supprimé
recherche des fichiers périmés... aucun résultat
running tests...

Document: overview
------------------
**********************************************************************
File "overview.rst", line 412, in default
Failed example:
    s = IISet(range(10))
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib64/python3.7/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest default[1]>", line 1, in <module>
        s = IISet(range(10))
    NameError: name 'IISet' is not defined
**********************************************************************
File "overview.rst", line 413, in default
Failed example:
    for i in list(s.keys()):  # this is well defined
        print(i)
        s.remove(i)
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib64/python3.7/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest default[2]>", line 3, in <module>
        s.remove(i)
    KeyError: [5]
**********************************************************************
File "overview.rst", line 426, in default
Failed example:
    list(s)
Expected:
    []
Got:
    [[5], [3]]
**********************************************************************
1 items had failures:
   3 of  37 in default
37 tests in 1 items.
34 passed and 3 failed.
***Test Failed*** 3 failures.
```