### PR TITLE
[WIP] Backward browsing

### DIFF
--- a/BTrees/BTreeModuleTemplate.c
+++ b/BTrees/BTreeModuleTemplate.c
@@ -270,6 +270,7 @@ typedef struct Sized_s {
 typedef struct Bucket_s {
   sizedcontainer_HEAD
   struct Bucket_s *next;    /* the bucket with the next-larger keys */
+  struct Bucket_s *prev;
   KEY_TYPE *keys;           /* 'len' keys, in increasing order */
   VALUE_TYPE *values;       /* 'len' corresponding values; NULL if a set */
 } Bucket;
@@ -497,7 +498,7 @@ BTree_Realloc(void *p, size_t sz)
  */
 static char *search_keywords[] = {"min", "max",
                                   "excludemin", "excludemax",
-                                  0};
+                                  "reverse", 0};
 
 #include "BTreeItemsTemplate.c"
 #include "BucketTemplate.c"

--- a/BTrees/BTreeTemplate.c
+++ b/BTrees/BTreeTemplate.c
@@ -1668,6 +1668,7 @@ BTree_rangeSearch(BTree *self, PyObject *args, PyObject *kw, char type)
     PyObject *max = Py_None;
     int excludemin = 0;
     int excludemax = 0;
+    int reverse = 0;
     int rc;
     Bucket *lowbucket = NULL;
     Bucket *highbucket = NULL;
@@ -1677,11 +1678,12 @@ BTree_rangeSearch(BTree *self, PyObject *args, PyObject *kw, char type)
 
     if (args)
     {
-        if (! PyArg_ParseTupleAndKeywords(args, kw, "|OOii", search_keywords,
+        if (! PyArg_ParseTupleAndKeywords(args, kw, "|OOiii", search_keywords,
                                         &min,
                                         &max,
                                         &excludemin,
-                                        &excludemax))
+                                        &excludemax,
+                                        &reverse))
         return NULL;
     }
 
@@ -1822,7 +1824,7 @@ BTree_rangeSearch(BTree *self, PyObject *args, PyObject *kw, char type)
 
     PER_UNUSE(self);
 
-    result = newBTreeItems(type, lowbucket, lowoffset, highbucket, highoffset);
+    result = newBTreeItems(type, lowbucket, lowoffset, highbucket, highoffset, reverse);
     Py_DECREF(lowbucket);
     Py_DECREF(highbucket);
     return result;
@@ -1841,7 +1843,7 @@ empty_and_decref_buckets:
 
 empty:
     PER_UNUSE(self);
-    return newBTreeItems(type, 0, 0, 0, 0);
+    return newBTreeItems(type, 0, 0, 0, 0, 0);
 }
 
 /*

--- a/BTrees/_base.py
+++ b/BTrees/_base.py
@@ -94,12 +94,14 @@ class _BucketBase(_Base):
 
     __slots__ = ('_keys',
                  '_next',
+                 '_prev',
                  '_to_key',
                 )
 
     def clear(self):
         self._keys = self._key_type()
         self._next = None
+        self._prev = None
 
     def __len__(self):
         return len(self._keys)
@@ -112,6 +114,8 @@ class _BucketBase(_Base):
         next = self._next
         if next is not None:
             self._next = next._next
+            if next._next is not None:
+                self._next._prev = self
 
     def _search(self, key):
         # Return non-negative index on success
@@ -159,7 +163,8 @@ class _BucketBase(_Base):
                 raise ValueError("no key satisfies the conditions")
 
     def _range(self, min=_marker, max=_marker,
-               excludemin=False, excludemax=False):
+               excludemin=False, excludemax=False,
+               reverse=False):
         if min is _marker or min is None:
             start = 0
             if excludemin:
@@ -185,11 +190,16 @@ class _BucketBase(_Base):
             else:
                 end = -end - 1
 
-        return start, end
+        if not reverse:
+            step = 1
+        else:
+            step = -1
+            start, end = end-1, start-1
+
+        return start, end, step
 
     def keys(self, *args, **kw):
-        start, end = self._range(*args, **kw)
-        return self._keys[start:end]
+        return list(self.iterkeys(*args, **kw))
 
     def iterkeys(self, *args, **kw):
         if not (args or kw):
@@ -380,22 +390,19 @@ class Bucket(_BucketBase):
         del self._keys[index:]
         del self._values[index:]
         new_instance._next = self._next
+        new_instance._prev = self
         self._next = new_instance
         return new_instance
 
     def values(self, *args, **kw):
-        start, end = self._range(*args, **kw)
-        return self._values[start:end]
+        return list(self.itervalues(*args, **kw))
 
     def itervalues(self, *args, **kw):
         values = self._values
         return (values[i] for i in xrange(*self._range(*args, **kw)))
 
     def items(self, *args, **kw):
-        keys = self._keys
-        values = self._values
-        return [(keys[i], values[i])
-                    for i in xrange(*self._range(*args, **kw))]
+        return list(self.iteritems(*args, **kw))
 
     def iteritems(self, *args, **kw):
         keys = self._keys
@@ -423,8 +430,12 @@ class Bucket(_BucketBase):
         self.clear()
         if len(state) == 2:
             state, self._next = state
+            if self._next and isinstance(self._next, type(self)):
+                self._next._prev = self
+
         else:
             self._next = None
+            self._prev = None
             state = state[0]
 
         keys = self._keys
@@ -783,6 +794,7 @@ class _Tree(_Base):
 
     __slots__ = ('_data',
                  '_firstbucket',
+                 '_lastbucket',
                 )
 
     def __new__(cls, *args):
@@ -792,6 +804,7 @@ class _Tree(_Base):
         # and _data and _firstbucket are never defined, unless we do it here.
         value._data = []
         value._firstbucket = None
+        value._lastbucket = None
         return value
 
     def setdefault(self, key, value):
@@ -826,6 +839,7 @@ class _Tree(_Base):
             # In the case of __init__, this was already set by __new__
             self._data = []
         self._firstbucket = None
+        self._lastbucket = None
 
     def __nonzero__(self):
         return bool(self._data)
@@ -886,23 +900,31 @@ class _Tree(_Base):
 
     def keys(self, min=_marker, max=_marker,
              excludemin=False, excludemax=False,
-             itertype='iterkeys'):
+             itertype='iterkeys', reverse=False):
         if not self._data:
             return ()
 
-        if min is not _marker and min is not None:
-            min = self._to_key(min)
-            bucket = self._findbucket(min)
+        if not reverse:
+            if min is not _marker and min is not None:
+                min = self._to_key(min)
+                bucket = self._findbucket(min)
+            else:
+                bucket = self._firstbucket
         else:
-            bucket = self._firstbucket
+            if max is not _marker and max is not None:
+                max = self._to_key(max)
+                bucket = self._findbucket(max)
+            else:
+                bucket = self._lastbucket
 
-        iterargs = min, max, excludemin, excludemax
+        iterargs = min, max, excludemin, excludemax, reverse
 
         return _TreeItems(bucket, itertype, iterargs)
 
     def iterkeys(self, min=_marker, max=_marker,
-                 excludemin=False, excludemax=False):
-        return iter(self.keys(min, max, excludemin, excludemax))
+                 excludemin=False, excludemax=False,
+                 reverse=False):
+        return iter(self.keys(min, max, excludemin, excludemax, reverse=reverse))
 
     def __iter__(self):
         return iter(self.keys())
@@ -944,6 +966,7 @@ class _Tree(_Base):
             index = 0
             child = self._bucket_type()
             self._firstbucket = child
+            self._lastbucket = child
             data.append(_TreeItem(None, child))
 
         result = child._set(key, value, ifunset)
@@ -974,11 +997,13 @@ class _Tree(_Base):
         self._data.insert(index+1, _TreeItem(new_child.minKey(), new_child))
         if len(self._data) >= self.max_internal_size * 2:
             self._split_root()
+        self._lastbucket = new_child
 
     def _split_root(self):
         child = type(self)()
         child._data = self._data
         child._firstbucket = self._firstbucket
+        child._lastbucket = self._lastbucket
         self._data = [_TreeItem(None, child)]
         self._grow(child, 0)
 
@@ -1216,6 +1241,7 @@ class _TreeItems(object):
         bucket = self.firstbucket
         itertype = self.itertype
         iterargs = self.iterargs
+        reverse = iterargs[4] if len(iterargs) >= 5 else False
         done = 0
         # Note that we don't mind if the first bucket yields no
         # results due to an idiosyncrasy in how range searches are done.
@@ -1225,7 +1251,11 @@ class _TreeItems(object):
                 done = 0
             if done:
                 return
-            bucket = bucket._next
+
+            if not reverse:
+                bucket = bucket._next
+            else:
+                bucket = bucket._prev
             done = 1
 
 
@@ -1258,20 +1288,24 @@ class Tree(_Tree):
         raise KeyError(key)
 
     def values(self, min=_marker, max=_marker,
-               excludemin=False, excludemax=False):
-        return self.keys(min, max, excludemin, excludemax, 'itervalues')
+               excludemin=False, excludemax=False,
+               reverse=False):
+        return self.keys(min, max, excludemin, excludemax, 'itervalues', reverse)
 
     def itervalues(self, min=_marker, max=_marker,
-                   excludemin=False, excludemax=False):
-        return iter(self.values(min, max, excludemin, excludemax))
+                   excludemin=False, excludemax=False,
+                   reverse=False):
+        return iter(self.values(min, max, excludemin, excludemax, reverse))
 
     def items(self, min=_marker, max=_marker,
-              excludemin=False, excludemax=False):
-        return self.keys(min, max, excludemin, excludemax, 'iteritems')
+              excludemin=False, excludemax=False,
+              reverse=False):
+        return self.keys(min, max, excludemin, excludemax, 'iteritems', reverse)
 
     def iteritems(self, min=_marker, max=_marker,
-                  excludemin=False, excludemax=False):
-        return iter(self.items(min, max, excludemin, excludemax))
+                  excludemin=False, excludemax=False,
+                  reverse=False):
+        return iter(self.items(min, max, excludemin, excludemax, reverse))
 
     def byValue(self, min):
         return reversed(

--- a/BTrees/tests/common.py
+++ b/BTrees/tests/common.py
@@ -809,6 +809,36 @@ class MappingBase(Base):
             self.assertEqual(list(t.iteritems()), list(t.items()))
 
     @uses_negative_keys_and_values
+    def testReverseIterators(self):
+        t = self._makeOne()
+
+        for keys in ([], [-2], [1, 4], list(range(-170, 2000, 6))):
+            t.clear()
+            for k in keys:
+                val = -3 * k
+                t[k] = val
+
+            self.assertEqual(list(t), keys)
+
+            #it = reversed(t)
+            #self.assertTrue(it is reversed(it))
+            #x = []
+            #try:
+            #    while 1:
+            #        x.append(next(it))
+            #except StopIteration:
+            #    pass
+            #self.assertEqual(x, keys)
+
+            self.assertEqual(list(t.iterkeys(reverse=True)), keys[::-1])
+            self.assertEqual(list(t.keys(reverse=True)), keys[::-1])
+            self.assertEqual(list(t.itervalues(reverse=True)), list(t.values())[::-1])
+            self.assertEqual(list(t.values(reverse=True)), list(t.values())[::-1])
+            self.assertEqual(list(t.iteritems(reverse=True)), list(t.items())[::-1])
+            self.assertEqual(list(t.items(reverse=True)), list(t.items())[::-1])
+
+
+    @uses_negative_keys_and_values
     def testRangedIterators(self):
         t = self._makeOne()
 

--- a/BTrees/tests/test__base.py
+++ b/BTrees/tests/test__base.py
@@ -151,72 +151,72 @@ class Test_BucketBase(unittest.TestCase):
 
     def test__range_defaults_empty(self):
         bucket = self._makeOne()
-        self.assertEqual(bucket._range(), (0, 0))
+        self.assertEqual(bucket._range(), (0, 0, 1))
 
     def test__range_defaults_filled(self):
         bucket = self._makeOne()
         bucket._keys = ['alpha', 'bravo', 'charlie', 'delta', 'echo']
-        self.assertEqual(bucket._range(), (0, 5))
+        self.assertEqual(bucket._range(), (0, 5, 1))
 
     def test__range_defaults_exclude_min(self):
         bucket = self._makeOne()
         bucket._keys = ['alpha', 'bravo', 'charlie', 'delta', 'echo']
-        self.assertEqual(bucket._range(excludemin=True), (1, 5))
+        self.assertEqual(bucket._range(excludemin=True), (1, 5, 1))
 
     def test__range_defaults_exclude_max(self):
         bucket = self._makeOne()
         bucket._keys = ['alpha', 'bravo', 'charlie', 'delta', 'echo']
-        self.assertEqual(bucket._range(excludemax=True), (0, 4))
+        self.assertEqual(bucket._range(excludemax=True), (0, 4, 1))
 
     def test__range_w_min_hit(self):
         bucket = self._makeOne()
         bucket._to_key = lambda x: x
         bucket._keys = ['alpha', 'bravo', 'charlie', 'delta', 'echo']
-        self.assertEqual(bucket._range(min='bravo'), (1, 5))
+        self.assertEqual(bucket._range(min='bravo'), (1, 5, 1))
 
     def test__range_w_min_miss(self):
         bucket = self._makeOne()
         bucket._to_key = lambda x: x
         bucket._keys = ['alpha', 'bravo', 'charlie', 'delta', 'echo']
-        self.assertEqual(bucket._range(min='candy'), (2, 5))
+        self.assertEqual(bucket._range(min='candy'), (2, 5, 1))
 
     def test__range_w_min_hit_w_exclude_min(self):
         bucket = self._makeOne()
         bucket._to_key = lambda x: x
         bucket._keys = ['alpha', 'bravo', 'charlie', 'delta', 'echo']
-        self.assertEqual(bucket._range(min='bravo', excludemin=True), (2, 5))
+        self.assertEqual(bucket._range(min='bravo', excludemin=True), (2, 5, 1))
 
     def test__range_w_min_miss_w_exclude_min(self):
         bucket = self._makeOne()
         bucket._to_key = lambda x: x
         bucket._keys = ['alpha', 'bravo', 'charlie', 'delta', 'echo']
         # 'excludemin' doesn't fire on miss
-        self.assertEqual(bucket._range(min='candy', excludemin=True), (2, 5))
+        self.assertEqual(bucket._range(min='candy', excludemin=True), (2, 5, 1))
 
     def test__range_w_max_hit(self):
         bucket = self._makeOne()
         bucket._to_key = lambda x: x
         bucket._keys = ['alpha', 'bravo', 'charlie', 'delta', 'echo']
-        self.assertEqual(bucket._range(max='delta'), (0, 4))
+        self.assertEqual(bucket._range(max='delta'), (0, 4, 1))
 
     def test__range_w_max_miss(self):
         bucket = self._makeOne()
         bucket._to_key = lambda x: x
         bucket._keys = ['alpha', 'bravo', 'charlie', 'delta', 'echo']
-        self.assertEqual(bucket._range(max='dandy'), (0, 3))
+        self.assertEqual(bucket._range(max='dandy'), (0, 3, 1))
 
     def test__range_w_max_hit_w_exclude_max(self):
         bucket = self._makeOne()
         bucket._to_key = lambda x: x
         bucket._keys = ['alpha', 'bravo', 'charlie', 'delta', 'echo']
-        self.assertEqual(bucket._range(max='delta', excludemax=True), (0, 3))
+        self.assertEqual(bucket._range(max='delta', excludemax=True), (0, 3, 1))
 
     def test__range_w_max_miss_w_exclude_max(self):
         bucket = self._makeOne()
         bucket._to_key = lambda x: x
         bucket._keys = ['alpha', 'bravo', 'charlie', 'delta', 'echo']
         # 'excludemax' doesn't fire on miss
-        self.assertEqual(bucket._range(max='dandy', excludemax=True), (0, 3))
+        self.assertEqual(bucket._range(max='dandy', excludemax=True), (0, 3, 1))
 
     def test_keys_defaults_empty(self):
         bucket = self._makeOne()

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ usedevelop = true
 extras =
     test
 commands =
-    zope-testrunner --test-path=. --auto-color --auto-progress []
+    zope-testrunner --test-path=. --auto-color --auto-progress [] {posargs}
 setenv =
     PYTHONFAULTHANDLER=1
     pure: PURE_PYTHON=1
@@ -29,7 +29,7 @@ deps =
 basepython =
     python3.6
 commands =
-    coverage run -m zope.testrunner --test-path=. --auto-color --auto-progress []
+    coverage run -m zope.testrunner --test-path=. --auto-color --auto-progress [] {posargs}
     coverage report --fail-under=92
 deps =
     coverage


### PR DESCRIPTION
I would like to:

- implement a `reverse` parameter on `keys`, `values`, `items`, `iterkeys`, `itervalues`, `iteritems` methods.
- implement a reversed iterator so `reversed` would work on BTrees, Buckets, TreeSets and Sets.
- allow slices steps of -1 on `BTreeItems`.

Here is a first attempt to implement the `reverse` parameter on BTrees and Buckets. I prefer to check with you if I am going the right way before I spend too much time on this.

Basically, when `reverse` is True, we start the iteration with the last bucket, and then go backward. To do this I set a `prev` pointer on buckets, that work the same way than `next` but is not stored in the state.