### PR TITLE
Ensure resolution order for all objects is consistent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,12 @@ jobs:
     - name: "Python: 2.7, pure (no C extensions)"
       python: 2.7
       env: PURE_PYTHON=1
-    - name: "Python: 3.6, pure (no C extensions), with coverage"
-      python: 3.6
-      env: PURE_PYTHON=1 WITH_COVERAGE=1
-    - name: "Python: 3.6, with coverage"
-      python: 3.6
-      env: WITH_COVERAGE=1
+    - name: "Python: 3.8, pure (no C extensions), with coverage, strict IRO"
+      python: 3.8
+      env: PURE_PYTHON=1 WITH_COVERAGE=1 ZOPE_INTERFACE_STRICT_IRO=1
+    - name: "Python: 3.8, with coverage, strict IRO"
+      python: 3.8
+      env: WITH_COVERAGE=1 ZOPE_INTERFACE_STRICT_IRO=1
 
     # manylinux wheel builds
     - name: 64-bit manylinux wheels (all Pythons)
@@ -91,9 +91,11 @@ install:
 
 script:
   - python --version
+# Temporary use of unittest over zope.testrunner; see tox.ini.
+# (WITH_COVERAGE implies STRICT_IRO)
   - |
     if [[ "$WITH_COVERAGE" == "1" ]]; then
-      python -m coverage run -m zope.testrunner --test-path=. --auto-color --auto-progress --verbose
+      python -m coverage run -m unittest discover -s .
     else
       python -m zope.testrunner --test-path=. --auto-color --auto-progress --verbose
     fi

--- a/BTrees/Interfaces.py
+++ b/BTrees/Interfaces.py
@@ -129,7 +129,7 @@ class ISet(IKeySequence, ISetMutable):
     pass
 
 
-class ITreeSet(IKeyed, ISetMutable):
+class ITreeSet(ISetMutable):
     pass
 
 class IMinimalDictionary(ISized, IKeyed):

--- a/BTrees/tests/test_dynamic_btrees.py
+++ b/BTrees/tests/test_dynamic_btrees.py
@@ -43,4 +43,9 @@ for family in _FAMILIES:
         _suite.addTest(unittest.defaultTestLoader.loadTestsFromModule(mod))
 
 def test_suite():
+    # zope.testrunner protocol
     return _suite
+
+def load_tests(loader, standard_tests, pattern): # pylint:disable=unused-argument
+    # Pure unittest protocol.
+    return test_suite()

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
   incorrectly left out names. See `PR 132
   <https://github.com/zopefoundation/BTrees/pull/132>`_.
 
+- Ensure the interface resolution order of all objects is consistent.
+  See `issue 137 <https://github.com/zopefoundation/BTrees/issues/137>`_.
 
 4.7.0 (2020-03-17)
 ==================

--- a/tox.ini
+++ b/tox.ini
@@ -10,9 +10,13 @@ usedevelop = true
 extras =
     test
 commands =
-    zope-testrunner --test-path=. --auto-color --auto-progress []
+    # Temporary work around. Avoid zope.testrunner pending
+    # https://github.com/zopefoundation/zope.security/issues/71
+    python -m unittest discover -s BTrees -t .
 setenv =
     PYTHONFAULTHANDLER=1
+    PYTHONDEVMODE=1
+    ZOPE_INTERFACE_STRICT_IRO=1
     pure: PURE_PYTHON=1
 
 #[testenv:jython]
@@ -33,6 +37,9 @@ commands =
     coverage report --fail-under=92
 deps =
     coverage
+# Temporary; see main testenv.
+setenv =
+    ZOPE_INTERFACE_STRICT_IRO=0
 
 [testenv:docs]
 basepython =


### PR DESCRIPTION
Fixes #137 

Requires a temporary switch to using unittest as the runner.