### PR TITLE
Shortcut operators for union, intersection and difference

### DIFF
--- a/BTrees/BTreeTemplate.c
+++ b/BTrees/BTreeTemplate.c
@@ -2425,7 +2425,7 @@ BTree_nonzero(BTree *self)
 
 static PyNumberMethods BTree_as_number_for_nonzero = {
     0,                                      /* nb_add */
-    0,                                      /* nb_subtract */
+    bucket_sub,                             /* nb_subtract */
     0,                                      /* nb_multiply */
 #ifndef PY3K
     0,                                      /* nb_divide */
@@ -2436,7 +2436,13 @@ static PyNumberMethods BTree_as_number_for_nonzero = {
     0,                                      /* nb_negative */
     0,                                      /* nb_positive */
     0,                                      /* nb_absolute */
-    (inquiry)BTree_nonzero                  /* nb_nonzero */
+    (inquiry)BTree_nonzero,                 /* nb_nonzero */
+    (unaryfunc)0,                           /* nb_invert */
+    (binaryfunc)0,                          /* nb_lshift */
+    (binaryfunc)0,                          /* nb_rshift */
+    bucket_and,                             /* nb_and */
+    (binaryfunc)0,                          /* nb_xor */
+    bucket_or,                              /* nb_or */
 };
 
 static PyTypeObject BTreeType = {
@@ -2459,6 +2465,9 @@ static PyTypeObject BTreeType = {
     0,                                      /* tp_getattro */
     0,                                      /* tp_setattro */
     0,                                      /* tp_as_buffer */
+#ifndef PY3K
+    Py_TPFLAGS_CHECKTYPES |
+#endif
     Py_TPFLAGS_DEFAULT |
     Py_TPFLAGS_HAVE_GC |
     Py_TPFLAGS_BASETYPE,                    /* tp_flags */

--- a/BTrees/BucketTemplate.c
+++ b/BTrees/BucketTemplate.c
@@ -12,6 +12,7 @@
 
 ****************************************************************************/
 
+#include "SetOpTemplate.h"
 #define BUCKETTEMPLATE_C "$Id$\n"
 
 /* Use BUCKET_SEARCH to find the index at which a key belongs.
@@ -1367,6 +1368,26 @@ bucket_setstate(Bucket *self, PyObject *state)
     return Py_None;
 }
 
+static PyObject *
+bucket_sub(PyObject *self, PyObject *other)
+{
+    PyObject *args = Py_BuildValue("OO", self, other);
+    return difference_m(NULL, args);
+}
+
+static PyObject *
+bucket_or(PyObject *self, PyObject *other)
+{
+    PyObject *args = Py_BuildValue("OO", self, other);
+    return union_m(NULL, args);
+}
+
+static PyObject *
+bucket_and(PyObject *self, PyObject *other)
+{
+    PyObject *args = Py_BuildValue("OO", self, other);
+    return intersection_m(NULL, args);
+}
 
 static PyObject *
 bucket_setdefault(Bucket *self, PyObject *args)
@@ -1847,6 +1868,29 @@ static PySequenceMethods Bucket_as_sequence = {
     0,                                  /* sq_inplace_repeat */
 };
 
+static PyNumberMethods Bucket_as_number = {
+     (binaryfunc)0,                     /* nb_add */
+     bucket_sub,                        /* nb_subtract */
+     (binaryfunc)0,                     /* nb_multiply */
+#ifndef PY3K
+     0,                                 /* nb_divide */
+#endif
+     (binaryfunc)0,                     /* nb_remainder */
+     (binaryfunc)0,                     /* nb_divmod */
+     (ternaryfunc)0,                    /* nb_power */
+     (unaryfunc)0,                      /* nb_negative */
+     (unaryfunc)0,                      /* nb_positive */
+     (unaryfunc)0,                      /* nb_absolute */
+     (inquiry)0,                        /* nb_bool */
+     (unaryfunc)0,                      /* nb_invert */
+     (binaryfunc)0,                     /* nb_lshift */
+     (binaryfunc)0,                     /* nb_rshift */
+     bucket_and,                        /* nb_and */
+     (binaryfunc)0,                     /* nb_xor */
+     bucket_or,                         /* nb_or */
+};
+
+
 static PyObject *
 bucket_repr(Bucket *self)
 {
@@ -1911,7 +1955,7 @@ static PyTypeObject BucketType = {
     0,                                      /* tp_setattr */
     0,                                      /* tp_compare */
     (reprfunc)bucket_repr,                  /* tp_repr */
-    0,                                      /* tp_as_number */
+    &Bucket_as_number,                      /* tp_as_number */
     &Bucket_as_sequence,                    /* tp_as_sequence */
     &Bucket_as_mapping,                     /* tp_as_mapping */
     0,                                      /* tp_hash */
@@ -1920,6 +1964,9 @@ static PyTypeObject BucketType = {
     0,                                      /* tp_getattro */
     0,                                      /* tp_setattro */
     0,                                      /* tp_as_buffer */
+#ifndef PY3K
+    Py_TPFLAGS_CHECKTYPES |
+#endif
     Py_TPFLAGS_DEFAULT |
     Py_TPFLAGS_HAVE_GC |
     Py_TPFLAGS_BASETYPE,                    /* tp_flags */

--- a/BTrees/Interfaces.py
+++ b/BTrees/Interfaces.py
@@ -320,16 +320,6 @@ class IMerge(Interface):
         collections.
         """
 
-    def __and__(self, other):
-        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.intersection`"""
-
-    def __or__(self, other):
-        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.union`"""
-
-    def __sub__(self, other):
-        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.difference`"""
-
-
 
 class IBTreeModule(Interface):
     """These are available in all modules (IOBTree, OIBTree, OOBTree, IIBTree,

--- a/BTrees/Interfaces.py
+++ b/BTrees/Interfaces.py
@@ -126,24 +126,24 @@ class IKeySequence(IKeyed, ISized):
 
 
 class ISet(IKeySequence, ISetMutable):
-    def __and__(self, other):
+    def __and__(other):
         """Shortcut for :meth:`~BTrees.Interfaces.IMerge.intersection`"""
 
-    def __or__(self, other):
+    def __or__(other):
         """Shortcut for :meth:`~BTrees.Interfaces.IMerge.union`"""
 
-    def __sub__(self, other):
+    def __sub__(other):
         """Shortcut for :meth:`~BTrees.Interfaces.IMerge.difference"""
 
 
 class ITreeSet(ISetMutable):
-    def __and__(self, other):
+    def __and__(other):
         """Shortcut for :meth:`~BTrees.Interfaces.IMerge.intersection`"""
 
-    def __or__(self, other):
+    def __or__(other):
         """Shortcut for :meth:`~BTrees.Interfaces.IMerge.union`"""
 
-    def __sub__(self, other):
+    def __sub__(other):
         """Shortcut for :meth:`~BTrees.Interfaces.IMerge.difference"""
 
 
@@ -282,13 +282,13 @@ class IBTree(IDictionaryIsh):
               key=generate_key()
         """
 
-    def __and__(self, other):
+    def __and__(other):
         """Shortcut for :meth:`~BTrees.Interfaces.IMerge.intersection`"""
 
-    def __or__(self, other):
+    def __or__(other):
         """Shortcut for :meth:`~BTrees.Interfaces.IMerge.union`"""
 
-    def __sub__(self, other):
+    def __sub__(other):
         """Shortcut for :meth:`~BTrees.Interfaces.IMerge.difference`"""
 
 

--- a/BTrees/Interfaces.py
+++ b/BTrees/Interfaces.py
@@ -277,6 +277,10 @@ class IMerge(Interface):
     :meth:`BTrees.IIBTree.IIBTree.union` can only be used with :class:`~BTrees.IIBTree.IIBTree`,
     :class:`~BTrees.IIBTree.IIBucket`, :class:`~BTrees.IIBTree.IISet`, and :class:`~BTrees.IIBTree.IITreeSet`.
 
+    The number protocols methods ``__and__``, ``__or__`` and ``__sub__`` are provided
+    by all the data structures. They are shortcuts for :meth:`~BTrees.Interfaces.IMerge.intersection`,
+    :meth:`~BTrees.Interfaces.IMerge.union` and :meth:`~BTrees.Interfaces.IMerge.difference`.
+
     The implementing module has a value type. The :class:`~BTrees.IOBTree.IOBTree` and :class:`~BTrees.OOBTree.OOBTree`
     modules have object value type. The :class:`~BTrees.IIBTree.IIBTree` and :class:`~BTrees.OIBTree.OIBTree` modules
     have integer value types. Other modules may be defined in the
@@ -315,6 +319,16 @@ class IMerge(Interface):
         The output is a Set containing matching keys from the input
         collections.
         """
+
+    def __and__(self, other):
+        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.intersection`"""
+
+    def __or__(self, other):
+        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.union`"""
+
+    def __sub__(self, other):
+        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.difference`"""
+
 
 
 class IBTreeModule(Interface):

--- a/BTrees/Interfaces.py
+++ b/BTrees/Interfaces.py
@@ -126,11 +126,26 @@ class IKeySequence(IKeyed, ISized):
 
 
 class ISet(IKeySequence, ISetMutable):
-    pass
+    def __and__(self, other):
+        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.intersection`"""
+
+    def __or__(self, other):
+        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.union`"""
+
+    def __sub__(self, other):
+        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.difference"""
 
 
 class ITreeSet(ISetMutable):
-    pass
+    def __and__(self, other):
+        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.intersection`"""
+
+    def __or__(self, other):
+        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.union`"""
+
+    def __sub__(self, other):
+        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.difference"""
+
 
 class IMinimalDictionary(ISized, IKeyed):
 
@@ -266,6 +281,15 @@ class IBTree(IDictionaryIsh):
           while not t.insert(key, value):
               key=generate_key()
         """
+
+    def __and__(self, other):
+        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.intersection`"""
+
+    def __or__(self, other):
+        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.union`"""
+
+    def __sub__(self, other):
+        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.difference`"""
 
 
 class IMerge(Interface):

--- a/BTrees/SetOpTemplate.c
+++ b/BTrees/SetOpTemplate.c
@@ -16,6 +16,7 @@
  Set operations
 ****************************************************************************/
 
+#include "SetOpTemplate.h"
 #define SETOPTEMPLATE_C "$Id$\n"
 
 #ifdef KEY_CHECK

--- a/BTrees/SetOpTemplate.h
+++ b/BTrees/SetOpTemplate.h
@@ -1,0 +1,15 @@
+# ifndef SETOPTEMPLATE_H
+# define SETOPTEMPLATE_H
+
+#include "Python.h"
+
+static PyObject *
+union_m(PyObject *ignored, PyObject *args);
+
+static PyObject *
+intersection_m(PyObject *ignored, PyObject *args);
+
+static PyObject *
+difference_m(PyObject *ignored, PyObject *args);
+
+# endif

--- a/BTrees/SetTemplate.c
+++ b/BTrees/SetTemplate.c
@@ -304,6 +304,28 @@ static PySequenceMethods set_as_sequence = {
     0,                                  /* sq_inplace_repeat */
 };
 
+static PyNumberMethods set_as_number = {
+     (binaryfunc)0,                     /* nb_add */
+     bucket_sub,                        /* nb_subtract */
+     (binaryfunc)0,                     /* nb_multiply */
+#ifndef PY3K
+     0,                                 /* nb_divide */
+#endif
+     (binaryfunc)0,                     /* nb_remainder */
+     (binaryfunc)0,                     /* nb_divmod */
+     (ternaryfunc)0,                    /* nb_power */
+     (unaryfunc)0,                      /* nb_negative */
+     (unaryfunc)0,                      /* nb_positive */
+     (unaryfunc)0,                      /* nb_absolute */
+     (inquiry)0,                        /* nb_bool */
+     (unaryfunc)0,                      /* nb_invert */
+     (binaryfunc)0,                     /* nb_lshift */
+     (binaryfunc)0,                     /* nb_rshift */
+     bucket_and,                        /* nb_and */
+     (binaryfunc)0,                     /* nb_xor */
+     bucket_or,                         /* nb_or */
+};
+
 static PyTypeObject SetType = {
     PyVarObject_HEAD_INIT(NULL, 0)      /* PyPersist_Type */
     MODULE_NAME MOD_NAME_PREFIX "Set",  /* tp_name */
@@ -315,7 +337,7 @@ static PyTypeObject SetType = {
     0,                                  /* tp_setattr */
     0,                                  /* tp_compare */
     (reprfunc)set_repr,                 /* tp_repr */
-    0,                                  /* tp_as_number */
+    &set_as_number,                     /* tp_as_number */
     &set_as_sequence,                   /* tp_as_sequence */
     0,                                  /* tp_as_mapping */
     0,                                  /* tp_hash */
@@ -324,6 +346,9 @@ static PyTypeObject SetType = {
     0,                                  /* tp_getattro */
     0,                                  /* tp_setattro */
     0,                                  /* tp_as_buffer */
+#ifndef PY3K
+    Py_TPFLAGS_CHECKTYPES |
+#endif
     Py_TPFLAGS_DEFAULT |
     Py_TPFLAGS_HAVE_GC |
     Py_TPFLAGS_BASETYPE,                /* tp_flags */

--- a/BTrees/TreeSetTemplate.c
+++ b/BTrees/TreeSetTemplate.c
@@ -230,6 +230,9 @@ static PyTypeObject TreeSetType =
     0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
+#ifndef PY3K
+    Py_TPFLAGS_CHECKTYPES |
+#endif
     Py_TPFLAGS_DEFAULT |
     Py_TPFLAGS_HAVE_GC |
     Py_TPFLAGS_BASETYPE,                        /* tp_flags */

--- a/BTrees/_base.py
+++ b/BTrees/_base.py
@@ -218,6 +218,16 @@ class _BucketBase(_Base):
         name = name[:-2] if name.endswith("Py") else name
         return "%s.%s(%r)" % (mod, name, items)
 
+    def __sub__(self, other):
+        return difference(self.__class__, self, other)
+
+    def __or__(self, other):
+        return union(self.__class__, self, other)
+
+    def __and__(self, other):
+        return intersection(self.__class__, self, other)
+
+
 class _SetIteration(object):
 
     __slots__ = ('to_iterate',
@@ -1142,6 +1152,16 @@ class _Tree(_Base):
         r = super(_Tree, self).__repr__()
         r = r.replace('Py', '')
         return r
+
+    def __sub__(self, other):
+        return difference(self.__class__, self, other)
+
+    def __or__(self, other):
+        return union(self.__class__, self, other)
+
+    def __and__(self, other):
+        return intersection(self.__class__, self, other)
+
 
 def _get_simple_btree_bucket_state(state):
     if state is None:

--- a/BTrees/tests/common.py
+++ b/BTrees/tests/common.py
@@ -2313,6 +2313,7 @@ class SetResult(object):
                 C = self.union(A, B)
                 self.assertTrue(not hasattr(C, "values"))
                 self.assertEqual(list(C), self._union(A, B))
+                self.assertEqual(set(A) | set(B), set(A | B))
 
     def testIntersection(self):
         inputs = self.As + self.Bs
@@ -2321,6 +2322,7 @@ class SetResult(object):
                 C = self.intersection(A, B)
                 self.assertTrue(not hasattr(C, "values"))
                 self.assertEqual(list(C), self._intersection(A, B))
+                self.assertEqual(set(A) & set(B), set(A & B))
 
     def testDifference(self):
         inputs = self.As + self.Bs
@@ -2334,6 +2336,7 @@ class SetResult(object):
                     self.assertEqual(list(C.items()), want)
                 else:
                     self.assertEqual(list(C), want)
+                self.assertEqual(set(A) - set(B), set(A - B))
 
     def testLargerInputs(self): # pylint:disable=too-many-locals
         from BTrees.IIBTree import IISet # pylint:disable=no-name-in-module

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,9 +10,9 @@
   <https://github.com/zopefoundation/BTrees/pull/143>`_ for details.
 - BTrees, TreeSet, Set and Buckets implements the ``__and__``,
   ``__or__`` and ``__sub__`` as shortcuts for
-  :meth:`~BTrees.Interfaces.IMerge.intersection`,
-  :meth:`~BTrees.Interfaces.IMerge.union` and
-  :meth:`~BTrees.Interfaces.IMerge.difference`.
+  ``~BTrees.Interfaces.IMerge.intersection``,
+  ``~BTrees.Interfaces.IMerge.union`` and
+  ``~BTrees.Interfaces.IMerge.difference``.
 
 
 4.7.2 (2020-04-07)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@
 4.7.3 (unreleased)
 ==================
 
-- Nothing changed yet.
+- BTrees, TreeSet, Set and Buckets implements the ``__and__``,
+  ``__or__`` and ``__sub__`` as shortcuts for
+  :meth:`~BTrees.Interfaces.IMerge.intersection`,
+  :meth:`~BTrees.Interfaces.IMerge.union` and
+  :meth:`~BTrees.Interfaces.IMerge.difference`.
 
 
 4.7.2 (2020-04-07)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,9 +10,9 @@
   <https://github.com/zopefoundation/BTrees/pull/143>`_ for details.
 - BTrees, TreeSet, Set and Buckets implements the ``__and__``,
   ``__or__`` and ``__sub__`` as shortcuts for
-  ``~BTrees.Interfaces.IMerge.intersection``,
-  ``~BTrees.Interfaces.IMerge.union`` and
-  ``~BTrees.Interfaces.IMerge.difference``.
+  ``BTrees.Interfaces.IMerge.intersection``,
+  ``BTrees.Interfaces.IMerge.union`` and
+  ``BTrees.Interfaces.IMerge.difference``.
 
 
 4.7.2 (2020-04-07)

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ extras =
 commands =
     # Temporary work around. Avoid zope.testrunner pending
     # https://github.com/zopefoundation/zope.security/issues/71
-    python -m unittest discover -s BTrees -t .
+    python -m unittest discover -s BTrees -t . {posargs}
 setenv =
     PYTHONFAULTHANDLER=1
     PYTHONDEVMODE=1


### PR DESCRIPTION
Fixes #142 
Implementation of `__sub__`,  `__or__` and `__and__` as shortcuts for `difference`, `union` and `intersection`.

This makes the usage of BTrees datastructures closer to native python sets, that support those operators.