### PR TITLE
Add linux aarch64 wheel support

### DIFF
--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -2,6 +2,9 @@
 
 set -e -x
 
+# Missing libffi on aarch64
+yum install -y libffi-devel
+
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     if [[ "${PYBIN}" == *"cp27"* ]] || \

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,13 @@ jobs:
       install: docker pull $DOCKER_IMAGE
       script: bash .manylinux.sh
 
+    - name: 64-bit aarch64 manylinux wheels (all Pythons)
+      arch: arm64
+      services: docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux2014_aarch64
+      install: docker pull $DOCKER_IMAGE
+      script: bash .manylinux.sh
+
     - name: 32-bit manylinux wheels (all Pythons)
       services: docker
       env: DOCKER_IMAGE=quay.io/pypa/manylinux2010_i686 PRE_CMD=linux32


### PR DESCRIPTION
Added linux aarch63 wheel support.
Related to #151. @d-maurer Could you please review this PR.