### PR TITLE
Make multiunion(), union(), difference(), and intersection() work with arbitrary iterables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,14 @@
 4.8.0 (unreleased)
 ==================
 
+- Make the ``multiunion``, ``union``, ``intersection``, and
+  ``difference`` functions accept arbitrary Python iterables (that
+  iterate across the correct types). Previously, the Python
+  implementation allowed this, but the C implementation only allowed
+  objects (like ``TreeSet`` or ``Bucket``) defined in the same module
+  providing the function. See `issue 24
+  <https://github.com/zopefoundation/BTrees/issues/24>`_.
+
 - Fix persistency bug in the Python version
   (`#118 <https://github.com/zopefoundation/BTrees/issues/118>`_).
 

--- a/src/BTrees/Interfaces.py
+++ b/src/BTrees/Interfaces.py
@@ -325,6 +325,9 @@ class IMerge(Interface):
 
         While *c1* must be one of those types, *c2* can be any Python iterable
         returning the correct types of objects.
+
+        .. versionchanged:: 4.8.0
+           Add support for *c2* to be an arbitrary iterable.
         """
 
     def union(c1, c2):
@@ -336,8 +339,11 @@ class IMerge(Interface):
         The output is a Set containing keys from the input
         collections.
 
-        While *c1* must be one of those types, *c2* can be any Python iterable
-        returning the correct types of objects.
+        *c1* and *c2* can be any Python iterables returning the
+        correct type of objects.
+
+        .. versionchanged:: 4.8.0
+           Add support for arbitrary iterables.
         """
 
     def intersection(c1, c2):
@@ -349,8 +355,11 @@ class IMerge(Interface):
         The output is a Set containing matching keys from the input
         collections.
 
-        While *c1* must be one of those types, *c2* can be any Python iterable
-        returning the correct types of objects.
+        *c1* and *c2* can be any Python iterables returning the
+        correct type of objects.
+
+        .. versionchanged:: 4.8.0
+           Add support for arbitrary iterables.
         """
 
 
@@ -490,6 +499,9 @@ class IMergeIntegerKey(IMerge):
         all the integers in all the inputs are sorted via a single
         linear-time radix sort, then duplicates are removed in a second
         linear-time pass.
+
+        .. versionchanged:: 4.8.0
+           Add support for arbitrary iterables of integers.
         """
 
 class IBTreeFamily(Interface):

--- a/src/BTrees/Interfaces.py
+++ b/src/BTrees/Interfaces.py
@@ -322,6 +322,9 @@ class IMerge(Interface):
 
         If neither c1 nor c2 is None, the output is a Set if c1 is a Set or
         TreeSet, and is a Bucket if c1 is a Bucket or BTree.
+
+        While *c1* must be one of those types, *c2* can be any Python iterable
+        returning the correct types of objects.
         """
 
     def union(c1, c2):
@@ -332,6 +335,9 @@ class IMerge(Interface):
 
         The output is a Set containing keys from the input
         collections.
+
+        While *c1* must be one of those types, *c2* can be any Python iterable
+        returning the correct types of objects.
         """
 
     def intersection(c1, c2):
@@ -342,6 +348,9 @@ class IMerge(Interface):
 
         The output is a Set containing matching keys from the input
         collections.
+
+        While *c1* must be one of those types, *c2* can be any Python iterable
+        returning the correct types of objects.
         """
 
 
@@ -469,6 +478,9 @@ class IMergeIntegerKey(IMerge):
         + A Bucket or BTree from the same module (for example, an
           :class:`BTrees.IOBTree.IOBTree` for :meth:`BTrees.IOBTree.multiunion`).  The keys of the
           mapping are added to the union.
+
+        + Any iterable Python object that iterates across integers. This
+          will be slower than the above types.
 
         The union is returned as a Set from the same module (for example,
         :meth:`BTrees.IIBTree.multiunion` returns an :class:`BTrees.IIBTree.IISet`).

--- a/src/BTrees/_base.py
+++ b/src/BTrees/_base.py
@@ -222,10 +222,10 @@ class _BucketBase(_Base):
         return difference(self.__class__, self, other)
 
     def __or__(self, other):
-        return union(self.__class__, self, other)
+        return union(self._set_type, self, other)
 
     def __and__(self, other):
-        return intersection(self.__class__, self, other)
+        return intersection(self._set_type, self, other)
 
 
 class _SetIteration(object):
@@ -1168,10 +1168,10 @@ class _Tree(_Base):
         return difference(self.__class__, self, other)
 
     def __or__(self, other):
-        return union(self.__class__, self, other)
+        return union(self._set_type, self, other)
 
     def __and__(self, other):
-        return intersection(self.__class__, self, other)
+        return intersection(self._set_type, self, other)
 
 
 def _get_simple_btree_bucket_state(state):
@@ -1392,7 +1392,7 @@ def union(set_type, o1, o2):
         return o1
     i1 = _SetIteration(o1, False, 0)
     i2 = _SetIteration(o2, False, 0)
-    result = o1._set_type()
+    result = set_type()
     def copy(i):
         result._keys.append(i.key)
     while i1.active and i2.active:
@@ -1422,7 +1422,7 @@ def intersection(set_type, o1, o2):
         return o1
     i1 = _SetIteration(o1, False, 0)
     i2 = _SetIteration(o2, False, 0)
-    result = o1._set_type()
+    result = set_type()
     def copy(i):
         result._keys.append(i.key)
     while i1.active and i2.active:

--- a/src/BTrees/tests/common.py
+++ b/src/BTrees/tests/common.py
@@ -2357,7 +2357,7 @@ class SetResult(object):
         for A in inputs:
             for B in inputs:
                 for convert in lambda x: x, list, tuple, set:
-                    C = self.union(A, convert(B))
+                    C = self.union(convert(A), convert(B))
                     self.assertTrue(not hasattr(C, "values"))
                     self.assertEqual(list(C), self._union(A, B))
                     self.assertEqual(set(A) | set(B), set(A | B))
@@ -2367,7 +2367,7 @@ class SetResult(object):
         for A in inputs:
             for B in inputs:
                 for convert in lambda x: x, list, tuple, set:
-                    C = self.intersection(A, convert(B))
+                    C = self.intersection(convert(A), convert(B))
                     self.assertTrue(not hasattr(C, "values"))
                     self.assertEqual(list(C), self._intersection(A, B))
                     self.assertEqual(set(A) & set(B), set(A & B))
@@ -2377,6 +2377,8 @@ class SetResult(object):
         for A in inputs:
             for B in inputs:
                 for convert in lambda x: x, list, tuple, set:
+                    # Difference is unlike the others: The first argument
+                    # must be a BTree type, in both C and Python.
                     C = self.difference(A, convert(B))
                     # Difference preserves LHS values.
                     self.assertEqual(hasattr(C, "values"), hasattr(A, "values"))

--- a/src/BTrees/tests/common.py
+++ b/src/BTrees/tests/common.py
@@ -121,7 +121,7 @@ class ZODBAccess(object):
         transaction.abort()
         root._p_jar.close()
 
-    
+
 class Base(ZODBAccess, SignedMixin):
     # Tests common to all types: sets, buckets, and BTrees
 
@@ -2261,7 +2261,7 @@ def makeBuilder(mapbuilder):
 
 # Subclasses have to set up:
 #     builders() - function returning functions to build inputs,
-#     each returned callable tkes an optional keys arg
+#     each returned callable takes an optional keys arg
 #     intersection, union, difference - set to the type-correct versions
 class SetResult(object):
     def setUp(self):
@@ -2302,18 +2302,18 @@ class SetResult(object):
     def testNone(self):
         for op in self.union, self.intersection, self.difference:
             C = op(None, None)
-            self.assertTrue(C is None)
+            self.assertIsNone(C)
 
         for op in self.union, self.intersection, self.difference:
             for A in self.As:
                 C = op(A, None)
-                self.assertTrue(C is A)
+                self.assertIs(C, A)
 
                 C = op(None, A)
                 if op == self.difference:
-                    self.assertTrue(C is None)
+                    self.assertIsNone(C, None)
                 else:
-                    self.assertTrue(C is A)
+                    self.assertIs(C, A)
 
     def testEmptyUnion(self):
         for A in self.As:
@@ -2356,33 +2356,36 @@ class SetResult(object):
         inputs = self.As + self.Bs
         for A in inputs:
             for B in inputs:
-                C = self.union(A, B)
-                self.assertTrue(not hasattr(C, "values"))
-                self.assertEqual(list(C), self._union(A, B))
-                self.assertEqual(set(A) | set(B), set(A | B))
+                for convert in lambda x: x, list, tuple, set:
+                    C = self.union(A, convert(B))
+                    self.assertTrue(not hasattr(C, "values"))
+                    self.assertEqual(list(C), self._union(A, B))
+                    self.assertEqual(set(A) | set(B), set(A | B))
 
     def testIntersection(self):
         inputs = self.As + self.Bs
         for A in inputs:
             for B in inputs:
-                C = self.intersection(A, B)
-                self.assertTrue(not hasattr(C, "values"))
-                self.assertEqual(list(C), self._intersection(A, B))
-                self.assertEqual(set(A) & set(B), set(A & B))
+                for convert in lambda x: x, list, tuple, set:
+                    C = self.intersection(A, convert(B))
+                    self.assertTrue(not hasattr(C, "values"))
+                    self.assertEqual(list(C), self._intersection(A, B))
+                    self.assertEqual(set(A) & set(B), set(A & B))
 
     def testDifference(self):
         inputs = self.As + self.Bs
         for A in inputs:
             for B in inputs:
-                C = self.difference(A, B)
-                # Difference preserves LHS values.
-                self.assertEqual(hasattr(C, "values"), hasattr(A, "values"))
-                want = self._difference(A, B)
-                if hasattr(A, "values"):
-                    self.assertEqual(list(C.items()), want)
-                else:
-                    self.assertEqual(list(C), want)
-                self.assertEqual(set(A) - set(B), set(A - B))
+                for convert in lambda x: x, list, tuple, set:
+                    C = self.difference(A, convert(B))
+                    # Difference preserves LHS values.
+                    self.assertEqual(hasattr(C, "values"), hasattr(A, "values"))
+                    want = self._difference(A, B)
+                    if hasattr(A, "values"):
+                        self.assertEqual(list(C.items()), want)
+                    else:
+                        self.assertEqual(list(C), want)
+                    self.assertEqual(set(A) - set(B), set(A - B))
 
     def testLargerInputs(self): # pylint:disable=too-many-locals
         from BTrees.IIBTree import IISet # pylint:disable=no-name-in-module
@@ -2564,7 +2567,7 @@ class MultiUnion(SignedMixin):
     def testEmpty(self):
         self.assertEqual(len(self.multiunion([])), 0)
 
-    def testOne(self):
+    def _testOne(self, builder):
         for sequence in (
                 [3],
                 list(range(20)),
@@ -2576,17 +2579,83 @@ class MultiUnion(SignedMixin):
             seq2 = list(reversed(sequence[:]))
             seqsorted = sorted(sequence[:])
             for seq in seq1, seq2, seqsorted:
-                for builder in self.mkset, self.mktreeset:
-                    input = builder(seq)
-                    output = self.multiunion([input])
-                    self.assertEqual(len(seq), len(output))
-                    self.assertEqual(seqsorted, list(output))
+                input = builder(seq)
+                output = self.multiunion([input])
+                self.assertEqual(len(seq), len(output))
+                self.assertEqual(seqsorted, list(output))
+
+    def testOneBTSet(self):
+        self._testOne(self.mkset)
+
+    def testOneBTTreeSet(self):
+        self._testOne(self.mktreeset)
+
+    def testOneList(self):
+        self._testOne(list)
+
+    def testOneTuple(self):
+        self._testOne(tuple)
+
+    def testOneSet(self):
+        self._testOne(set)
+
+    def testOneGenerator(self):
+        def generator(seq):
+            for i in seq:
+                yield i
+
+        self._testOne(generator)
 
     def testValuesIgnored(self):
-        for builder in self.mkbucket, self.mkbtree:
+        for builder in self.mkbucket, self.mkbtree, dict:
             input = builder([(1, 2), (3, 4), (5, 6)])
             output = self.multiunion([input])
             self.assertEqual([1, 3, 5], list(output))
+
+    def testValuesIgnoredNonInteger(self):
+        # This only uses a dict because the bucket and tree can't
+        # hold non-integers.
+        i1 = {1: 'a', 2: 'b'}
+        i2 = {1: 'c', 3: 'd'}
+
+        output = self.multiunion((i1, i2))
+        self.assertEqual([1, 2, 3], list(output))
+
+    def testRangeInputs(self):
+        i1 = range(3)
+        i2 = range(7)
+
+        output = self.multiunion((i1, i2))
+        self.assertEqual([0, 1, 2, 3, 4, 5, 6], list(output))
+
+    def testNegativeKeys(self):
+        i1 = (-1, -2, -3)
+        i2 = (0, 1, 2)
+
+        if not self.SUPPORTS_NEGATIVE_KEYS:
+            with self.assertRaises(TypeError):
+                self.multiunion((i2, i1))
+        else:
+            output = self.multiunion((i2, i1))
+            self.assertEqual([-3, -2, -1, 0, 1, 2], list(output))
+
+    def testOneIterableWithBadKeys(self):
+        i1 = [1, 2, 3, 'a']
+        for kind in list, tuple:
+            with self.assertRaises(TypeError):
+                self.multiunion((kind(i1),))
+
+    def testBadIterable(self):
+        class MyException(Exception):
+            pass
+
+        def gen():
+            for i in range(3):
+                yield i
+            raise MyException
+
+        with self.assertRaises(MyException):
+            self.multiunion((gen(),))
 
     def testBigInput(self):
         N = 100000

--- a/src/BTrees/tests/test__base.py
+++ b/src/BTrees/tests/test__base.py
@@ -2610,8 +2610,8 @@ class Test_union(unittest.TestCase, _SetObBase):
     def test_lhs_mapping_rhs_set(self):
         lhs = self._makeMapping({'a': 13, 'b': 12, 'c': 11})
         rhs = self._makeSet('a', 'd')
-        result = self._callFUT(lhs.__class__, lhs, rhs)
-        self.assertTrue(isinstance(result, _Set))
+        result = self._callFUT(lhs._set_type, lhs, rhs)
+        self.assertIsInstance(result, _Set)
         self.assertEqual(list(result), ['a', 'b', 'c', 'd'])
 
     def test_both_mappings_rhs_empty(self):
@@ -2662,8 +2662,8 @@ class Test_intersection(unittest.TestCase, _SetObBase):
     def test_lhs_mapping_rhs_set(self):
         lhs = self._makeMapping({'a': 13, 'b': 12, 'c': 11})
         rhs = self._makeSet('a', 'd')
-        result = self._callFUT(lhs.__class__, lhs, rhs)
-        self.assertTrue(isinstance(result, _Set))
+        result = self._callFUT(lhs._set_type, lhs, rhs)
+        self.assertIsInstance(result, _Set)
         self.assertEqual(list(result), ['a'])
 
     def test_both_mappings_rhs_empty(self):


### PR DESCRIPTION
The Python implementation already did this, so this only updates the C version to match.

For multiunion, all arguments can be arbitrary iterables. The others derive their return type from the first argument, so it must still be a BTree object, but the second can be anything. (And technically, this limitation only applies to the python version; the C version actually accepts anything for both arguments, except for `difference` which also has the same limitation. I wasn't motivated to fix the Python version to accept arbitrary items in the first argument. But I will open a bug report if this gets merged.)

Fixes #24