### PR TITLE
Python 2: Forbid type objects as keys.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,13 @@
 4.8.0 (unreleased)
 ==================
 
+- Make Python 2 forbid the use of type objects as keys (unless a
+  custom metaclass is used that implements comparison as required by
+  BTrees.) On Python 3, types are not orderable so they were already
+  forbidden, but on Python 2 types can be ordered by memory address,
+  which makes them unsuitable for use as keys. See `issue
+  <https://github.com/zopefoundation/BTrees/issues/153>`_.
+
 - Make the ``multiunion``, ``union``, ``intersection``, and
   ``difference`` functions accept arbitrary Python iterables (that
   iterate across the correct types). Previously, the Python

--- a/src/BTrees/SetTemplate.c
+++ b/src/BTrees/SetTemplate.c
@@ -106,10 +106,7 @@ Set_discard(Bucket* self, PyObject* args)
         return NULL;
 
     if (_bucket_set(self, key, NULL, 0, 1, 0) < 0) {
-        /* XXX: After PR#162, this should change to
-           BTree_ShouldSuppressKeyError() */
-        PyObject* exc_type = PyErr_Occurred();
-        if (exc_type == PyExc_KeyError) {
+        if (BTree_ShouldSuppressKeyError()) {
             PyErr_Clear();
         }
         else if (PyErr_ExceptionMatches(PyExc_TypeError)) {
@@ -462,10 +459,7 @@ set_isub(Bucket* self, PyObject* other)
                 }
             }
             if (_bucket_set(self, v, NULL, 0, 1, 0) < 0) {
-                /* XXX: With PR#162 this can be changed to
-                   BTree_ShouldSuppressKeyError() */
-                PyObject* exc_type = PyErr_Occurred();
-                if (exc_type == PyExc_KeyError) {
+                if (BTree_ShouldSuppressKeyError()) {
                     PyErr_Clear();
                 }
                 else {

--- a/src/BTrees/TreeSetTemplate.c
+++ b/src/BTrees/TreeSetTemplate.c
@@ -110,10 +110,7 @@ TreeSet_discard(BTree *self, PyObject *args)
         return NULL;
 
     if (_BTree_set(self, key, NULL, 0, 1) < 0) {
-        /* XXX: After PR#162, this should change to
-           BTree_ShouldSuppressKeyError() */
-        PyObject* exc_type = PyErr_Occurred();
-        if (exc_type == PyExc_KeyError) {
+        if (BTree_ShouldSuppressKeyError()) {
             PyErr_Clear();
         }
         else if (PyErr_ExceptionMatches(PyExc_TypeError)) {
@@ -382,10 +379,7 @@ TreeSet_isub(BTree* self, PyObject* other)
                 }
             }
             if (_BTree_set(self, v, NULL, 0, 1) < 0) {
-                /* XXX: With PR#162 this can be changed to
-                   BTree_ShouldSuppressKeyError() */
-                PyObject* exc_type = PyErr_Occurred();
-                if (exc_type == PyExc_KeyError) {
+                if (BTree_ShouldSuppressKeyError()) {
                     PyErr_Clear();
                 }
                 else {

--- a/src/BTrees/_datatypes.py
+++ b/src/BTrees/_datatypes.py
@@ -157,9 +157,17 @@ class Any(DataType):
 
 class _HasDefaultComparison(ABC):
     """
-    An ABC for checking whether an item has default comparison.
+    An `ABC <https://docs.python.org/3/library/abc.html>_` for
+    checking whether an item has default comparison.
 
-    This automatically gets us some caching.
+    All we have to do is override ``__subclasshook__`` to implement an
+    algorithm determining whether a class has default comparison.
+    Python and the ABC machinery will take care of translating
+    ``isinstance(thing, _HasDefaultComparison)`` into something like
+    ``_HasDefaultComparison.__subclasshook__(type(thing))``. The ABC
+    handles caching the answer (based on exact classes, no MRO), and
+    getting the type from ``thing`` (including mostly dealing with
+    old-style) classes on Python 2.
     """
 
     # Comparisons only use special methods defined on the

--- a/src/BTrees/_datatypes.py
+++ b/src/BTrees/_datatypes.py
@@ -20,6 +20,13 @@ from operator import index as object_to_index
 from struct import Struct
 from struct import error as struct_error
 
+try:
+    from abc import ABC
+except ImportError:
+    # Python < 3.4
+    from abc import ABCMeta
+    ABC = ABCMeta('ABC', (object,), {})
+
 from ._compat import int_types
 from .utils import Lazy
 
@@ -147,6 +154,80 @@ class Any(DataType):
         return False
 
 
+
+class _HasDefaultComparison(ABC):
+    """
+    An ABC for checking whether an item has default comparison.
+
+    This automatically gets us some caching.
+    """
+
+    # Comparisons only use special methods defined on the
+    # type, not instance variables.
+
+    # On CPython 2, every subclass of object inherits __lt__
+    # (unless it overrides), and it has ``__objclass__`` of ``type``
+    # (of course it is also the same object as ``_object_lt`` at
+    # that point). Also, interestingly, CPython 2 classes inherit
+    # ``__lt__`` from ``type``, but *instances* do not.
+    #
+    # On CPython 3, classes inherit __lt__ with ``__objclass__`` of ``object``.
+    # On PyPy2, classes don't inherit any __lt__.
+    # On PyPy3, they do.
+    #
+    # Test these conditions at runtime and define the method variant
+    # appropriately.
+    #
+    # Remember the method is checking if the object has default comparison
+    assert '__lt__' not in DataType.__dict__
+    if hasattr(DataType, '__lt__'):
+        # CPython 2 or CPython 3 or PyPy3
+        if getattr(DataType.__lt__, '__objclass__', None) is object:
+            # CPython 3
+            @classmethod
+            def __subclasshook__(cls, C, _NoneType=type(None)):
+                if C is _NoneType:
+                    return False
+                defining_class = getattr(C.__lt__, '__objclass__', None)
+                if defining_class is None:
+                    # Implemented in Python
+                    return False
+                return C.__lt__.__objclass__ is object
+        elif getattr(DataType.__lt__, '__objclass__', None) is type:
+            # CPython 2
+            @classmethod
+            def __subclasshook__(cls, C, _NoneType=type(None)):
+                if C is _NoneType:
+                    return False
+                # If C is an old-style class, it may not even have __lt__
+                if isinstance(C, type):
+                    lt = C.__lt__
+                else:
+                    lt = getattr(C, '__lt__', None)
+                if lt is not None:
+                    defining_class = getattr(lt, '__objclass__', None)
+                    if defining_class is None:
+                        # Implemented in Python
+                        return False
+                    if defining_class is not type:
+                        return False
+                return not hasattr(C, '__cmp__')
+        else:
+            # PyPy3
+            @classmethod
+            def __subclasshook__(cls, C, _object_lt=object.__lt__, _NoneType=type(None)):
+                if C is _NoneType:
+                    return False
+                return C.__lt__ is _object_lt
+    else:
+        # PyPy2
+        @classmethod
+        def __subclasshook__(cls, C, _NoneType=type(None)):
+            if C is _NoneType:
+                return False
+            return not hasattr(C, '__lt__') and not hasattr(C, '__cmp__')
+
+
 class O(KeyDataType):
     """
     Arbitrary (sortable) Python objects.
@@ -161,58 +242,9 @@ class O(KeyDataType):
     def supports_value_union(self):
         return False
 
-    @staticmethod
-    def _check_default_comparison(
-            item,
-            # PyPy2 doesn't define __lt__ on object; PyPy3 and
-            # CPython 2 and 3 do.
-            _object_lt=getattr(object, '__lt__', object())
-    ):
-        # Enforce test that key has non-default comparison.
-        # (With the exception of None, because we define a sort order
-        # for it.)
-
-        if item is None:
-            return
-
-        if type(item) is object: # pylint:disable=unidiomatic-typecheck
-            raise TypeError("Can't use object() as keys")
-
-        # Now more complicated checks to be sure we didn't
-        # inherit default comparison on any version of Python.
-
-
-        # TODO: Using a custom ABC and doing ``isinstance(item, NoDefaultComparison)``
-        # would automatically gain us caching.
-
-        # XXX: Comparisons only use special methods defined on the
-        # type, not instance variables. So shouldn't this be getattr(type(key)...)?
-        # Note that changes some things below; for example, on CPython 2,
-        # every subclass of object inherits __lt__ (unless it overrides), and it
-        # has __objclass__ of ``type`` (of course it is also the same object
-        # as ``_object_lt`` at that point). Also, weirdly, CPython 2 classes inherit
-        # ``__lt__``, but *instances* do not.
-
-        lt = getattr(item, '__lt__', None)
-        if lt is not None:
-            # CPython 2 and 3 follow PEP 252, defining '__objclass__'
-            # for methods of builtin types like str; methods of
-            # classes defined in Python don't get it. ``__objclass__``
-            if getattr(lt, '__objclass__', None) is object:
-                lt = None  # pragma: no cover Py3k
-            # PyPy3 doesn't follow PEP 252, but defines '__func__'
-            elif getattr(lt, '__func__', None) is _object_lt:
-                lt = None  # pragma: no cover PyPy3
-
-        if (lt is None
-                # TODO: Shouldn't we only check __cmp__ on Python 2?
-                # Python 3 won't use it.
-                and getattr(item, '__cmp__', None) is None):
-            raise TypeError("Object has default comparison")
-
-
     def __call__(self, item):
-        self._check_default_comparison(item)
+        if isinstance(item, _HasDefaultComparison):
+            raise TypeError("Object of class %s has default comparison" % (type(item).__name__,))
         return item
 
 

--- a/src/BTrees/_datatypes.py
+++ b/src/BTrees/_datatypes.py
@@ -23,7 +23,7 @@ from struct import error as struct_error
 try:
     from abc import ABC
 except ImportError:
-    # Python < 3.4
+    # Python < 3.4 (specifically, Python 2)
     from abc import ABCMeta
     ABC = ABCMeta('ABC', (object,), {})
 

--- a/src/BTrees/objectkeymacros.h
+++ b/src/BTrees/objectkeymacros.h
@@ -19,14 +19,23 @@ check_argument_cmp(PyObject *arg)
       return 1;
     }
 
+
 #ifdef PY3K
     if (Py_TYPE(arg)->tp_richcompare == Py_TYPE(object_)->tp_richcompare)
 #else
-    if (Py_TYPE(arg)->tp_richcompare == NULL
-        && Py_TYPE(arg)->tp_compare == Py_TYPE(object_)->tp_compare)
+    if ((Py_TYPE(arg)->tp_richcompare == NULL
+	 && Py_TYPE(arg)->tp_compare == Py_TYPE(object_)->tp_compare)
+	/* Also exclude new-style classes. On Python 2, they can be compared,
+	   but order by address, making them not suitable for BTrees. */
+	|| PyType_CheckExact(arg)
+	/* But let classes with a meta class that implements comparison through. */
+	|| (PyType_Check(arg) && Py_TYPE(arg)->tp_richcompare == PyType_Type.tp_richcompare)
+	)
 #endif
     {
-        PyErr_SetString(PyExc_TypeError, "Object has default comparison");
+        PyErr_Format(PyExc_TypeError,
+		     "Object of class %s has default comparison",
+		     Py_TYPE(arg)->tp_name);
         return 0;
     }
     return 1;

--- a/src/BTrees/tests/common.py
+++ b/src/BTrees/tests/common.py
@@ -1143,6 +1143,32 @@ class MappingBase(Base): # pylint:disable=too-many-public-methods
     def test_assign_value_type_None(self):
         self.__test_value(None)
 
+    def testNewStyleClassAsKeyNotAllowed(self):
+        m = self._makeOne()
+        class New(object):
+            pass
+
+        with self.assertRaises(TypeError):
+            m[New] = self.getTwoValues()[0]
+
+    def testOldStyleClassAsKeyNotALlowed(self):
+        m = self._makeOne()
+        class Old: # Python 2: Old style class
+            pass
+
+        with self.assertRaises(TypeError):
+            m[Old] = self.getTwoValues()[0]
+
+    def testNewStyleClassWithCustomMetaClassNotAllowed(self):
+
+        class Meta(type):
+            pass
+
+        cls = Meta('Class', (object,), {})
+        m = self._makeOne()
+        with self.assertRaises(TypeError):
+            m[cls] = self.getTwoValues()[0]
+
     def testEmptyFirstBucketReportedByGuido(self):
         # This was for Integer keys
         from .._compat import xrange


### PR DESCRIPTION
Fixes #153.

Also take the opportunity to clean up the TODOs in _datatypes.py with regards to checking for default comparison: Use a metaclass so we get caching, and only check for the special methods on the type object.