### PR TITLE
Register BTree/Bucket as MutableMapping and Set/TreeSet as MutableSet, add missing methods/operators

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,20 @@
   of each module actually provide the interfaces defined in
   ``BTrees.Interfaces``. Previously, they provided no interfaces.
 
+- Make all the BTree and Bucket objects instances of
+  ``collections.abc.MutableMapping`` (that is, ``isinstance(btree,
+  MutableMapping)`` is now true; no actual inheritance has changed).
+  As part of this, they now provide the ``popitem()`` method.
+
+- Make all the TreeSet and Set objects instances of
+  ``collections.abc.MutableSet`` (that is, ``isinstance(tree_set,
+  MutableSet)`` is now true; no actual inheritance has changed).
+  As part of this, they now provide several more methods, including
+  ``isdisjoint``, ``discard``, and ``pop``, and support in-place
+  mutation operators such as ``tree_set |= other``, ``tree_set +=
+  other``, ``tree_set -= other`` and ``tree_set ^= other``. See `issue
+  121 <https://github.com/zopefoundation/BTrees/issues/121>`_.
+
 - Update the definitions of ``ISized`` and ``IReadSequence`` to simply
   be ``zope.interface.common.collections.ISized`` and
   ``zope.interface.common.sequence.IMinimalSequence`` respectively.

--- a/src/BTrees/BTreeTemplate.c
+++ b/src/BTrees/BTreeTemplate.c
@@ -2090,7 +2090,7 @@ BTree_popitem(BTree* self, PyObject* args)
     }
 
     Py_DECREF(key);
-    return result_val;
+    return result;
 }
 
 

--- a/src/BTrees/BTreeTemplate.c
+++ b/src/BTrees/BTreeTemplate.c
@@ -2058,6 +2058,43 @@ BTree_pop(BTree *self, PyObject *args)
     return NULL;
 }
 
+
+static PyObject*
+BTree_popitem(BTree* self, PyObject* args)
+{
+    PyObject* key = NULL;
+    PyObject* pop_args = NULL;
+    PyObject* result_val = NULL;
+    PyObject* result = NULL;
+
+    if (PyTuple_Size(args) != 0) {
+        PyErr_SetString(PyExc_TypeError, "popitem(): Takes no arguments.");
+        return NULL;
+    }
+
+    key = BTree_minKey(self, args); /* reuse existing empty tuple. */
+    if (!key) {
+        PyErr_Clear();
+        PyErr_SetString(PyExc_KeyError, "popitem(): empty BTree.");
+        return NULL;
+    }
+
+    pop_args = PyTuple_Pack(1, key);
+    if (pop_args) {
+        result_val = BTree_pop(self, pop_args);
+        Py_DECREF(pop_args);
+        if (result_val) {
+            result = PyTuple_Pack(2, key, result_val);
+            Py_DECREF(result_val);
+        }
+    }
+
+    Py_DECREF(key);
+    return result_val;
+}
+
+
+
 /* Search BTree self for key.  This is the sq_contains slot of the
  * PySequenceMethods.
  *
@@ -2229,6 +2266,10 @@ static struct PyMethodDef BTree_methods[] = {
      "D.pop(k[, d]) -> v, remove key and return the corresponding value.\n\n"
      "If key is not found, d is returned if given, otherwise KeyError\n"
      "is raised."},
+
+    {"popitem", (PyCFunction)BTree_popitem, METH_VARARGS,
+     "D.popitem() -> (k, v), remove and return some (key, value) pair\n"
+     "as a 2-tuple; but raise KeyError if D is empty."},
 
     {"maxKey", (PyCFunction) BTree_maxKey, METH_VARARGS,
      "maxKey([max]) -> key\n\n"

--- a/src/BTrees/BucketTemplate.c
+++ b/src/BTrees/BucketTemplate.c
@@ -1496,7 +1496,7 @@ bucket_popitem(Bucket* self, PyObject* args)
     }
 
     Py_DECREF(key);
-    return result_val;
+    return result;
 }
 
 

--- a/src/BTrees/Interfaces.py
+++ b/src/BTrees/Interfaces.py
@@ -105,6 +105,82 @@ class ISetMutable(IKeyed):
     def update(seq):
         """Add the items from the given sequence to the set."""
 
+    def __and__(other):
+        """
+        Shortcut for :meth:`~BTrees.Interfaces.IMerge.intersection`
+
+        .. versionadded:: 4.8.0
+        """
+
+    def __iand__(other):
+        """
+        As for :meth:`set.intersection_update`: Update this object,
+        keeping only elements found in both it and other.
+
+        .. versionadded:: 4.8.0
+        """
+
+    def __or__(other):
+        """
+        Shortcut for :meth:`~BTrees.Interfaces.IMerge.union`
+
+        .. versionadded:: 4.8.0
+        """
+
+    def __ior__(other):
+        """
+        As for :meth:`set.update`: Update this object, adding
+        elements from *other*.
+
+        .. versionadded:: 4.8.0
+        """
+
+    def __sub__(other):
+        """
+        Shortcut for :meth:`~BTrees.Interfaces.IMerge.difference`
+
+        .. versionadded:: 4.8.0
+        """
+
+    def __isub__(other):
+        """
+        As for :meth:`set.difference_update`: Update this object,
+        removing elements found in *other*.
+
+        .. versionadded:: 4.8.0
+        """
+
+    def isdisjoint(other):
+        """
+        As for :meth:`set.isdisjoint`: Return True if the set has no
+        elements in common with other.
+
+        .. versionadded:: 4.8.0
+        """
+
+    def discard(key):
+        """
+        As for :meth:`set.discard`: Remove the *key* from the set,
+        but only if it is present.
+
+        .. versionadded:: 4.8.0
+        """
+
+    def pop():
+        """
+        As for :meth:`set.pop`: Remove and return an arbitrary element;
+        raise :exc:`KeyError` if the object is empty.
+
+        .. versionadded:: 4.8.0
+        """
+
+    def __ixor__(other):
+        """
+        As for :meth:`set.symmetric_difference_update`: Update this object,
+        keeping only elements found in either set but not in both.
+
+        .. versionadded:: 4.8.0
+        """
 
 class IKeySequence(IKeyed, ISized):
 
@@ -117,26 +193,14 @@ class IKeySequence(IKeyed, ISized):
 
 
 class ISet(ISetMutable, IKeySequence):
-    def __and__(other):
-        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.intersection`"""
-
-    def __or__(other):
-        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.union`"""
-
-    def __sub__(other):
-        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.difference"""
-
+    """
+    A set of unique items stored in a single persistent object.
+    """
 
 class ITreeSet(ISetMutable):
-    def __and__(other):
-        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.intersection`"""
-
-    def __or__(other):
-        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.union`"""
-
-    def __sub__(other):
-        """Shortcut for :meth:`~BTrees.Interfaces.IMerge.difference"""
-
+    """
+    A set of unique items stored in a tree of persistent objects.
+    """
 
 
 class IMinimalDictionary(IKeyed, IMapping):
@@ -264,6 +328,14 @@ class IDictionaryIsh(IMinimalDictionary):
 
         If key is not found, d is returned if given, otherwise :class:`KeyError` is
         raised.
+        """
+
+    def popitem():
+        """
+        D.popitem() -> (k, v), remove and return some (key, value) pair
+        as a 2-tuple; but raise KeyError if D is empty.
+
+        .. versionadded:: 4.8.0
         """
 
 

--- a/src/BTrees/_base.py
+++ b/src/BTrees/_base.py
@@ -617,7 +617,9 @@ class Bucket(_MutableMappingMixin, _BucketBase):
 class _MutableSetMixin(object):
     # Like _MutableMappingMixin, but for sets.
     def isdisjoint(self, other):
-        'Return True if two sets have a null intersection.'
+        """
+        Return True if two sets have a null intersection.
+        """
         for value in other:
             if value in self:
                 return False

--- a/src/BTrees/_base.py
+++ b/src/BTrees/_base.py
@@ -90,7 +90,30 @@ class _Base(Persistent):
 
         _BTree_reduce_up_bound = _BTree_reduce_as
 
-class _BucketBase(_Base):
+class _ArithmeticMixin(object):
+    def __sub__(self, other):
+        return difference(self.__class__, self, other)
+
+    def __rsub__(self, other):
+        return difference(self._set_type, type(self)(other), self)
+
+    def __or__(self, other):
+        return union(self._set_type, self, other)
+
+    __ror__ = __or__
+
+    def __and__(self, other):
+        return intersection(self._set_type, self, other)
+
+    __rand__ = __and__
+
+    def __xor__(self, other):
+        return (self - other) | (other - self)
+
+    __rxor__ = __xor__
+
+
+class _BucketBase(_ArithmeticMixin, _Base):
 
     __slots__ = ('_keys',
                  '_next',
@@ -218,15 +241,6 @@ class _BucketBase(_Base):
         name = name[:-2] if name.endswith("Py") else name
         return "%s.%s(%r)" % (mod, name, items)
 
-    def __sub__(self, other):
-        return difference(self.__class__, self, other)
-
-    def __or__(self, other):
-        return union(self._set_type, self, other)
-
-    def __and__(self, other):
-        return intersection(self._set_type, self, other)
-
 
 class _SetIteration(object):
 
@@ -279,8 +293,26 @@ class _SetIteration(object):
 
         return self
 
+class _MutableMappingMixin(object):
+    # Methods defined in collections.abc.MutableMapping that
+    # Bucket and Tree should both implement and can implement
+    # the same. We don't want to extend that class though,
+    # as the C version cannot.
+    def popitem(self):
+        """
+        D.popitem() -> (k, v), remove and return some (key, value) pair
+        as a 2-tuple; but raise KeyError if D is empty.
+        """
+        try:
+            key = next(iter(self))
+        except StopIteration:
+            raise KeyError
+        value = self[key]
+        del self[key]
+        return key, value
 
-class Bucket(_BucketBase):
+
+class Bucket(_MutableMappingMixin, _BucketBase):
 
     __slots__ = ()
     _value_type = list
@@ -582,7 +614,68 @@ class Bucket(_BucketBase):
     def __repr__(self):
         return self._repr_helper(self.items())
 
-class Set(_BucketBase):
+class _MutableSetMixin(object):
+    # Like _MutableMappingMixin, but for sets.
+    def isdisjoint(self, other):
+        'Return True if two sets have a null intersection.'
+        for value in other:
+            if value in self:
+                return False
+        return True
+
+    def discard(self, key):
+        """
+        Remove an element from the set if it is a member.
+
+        If not, do nothing and raise no exception.
+        """
+        # Written this way to avoid catching and accidentally
+        # ignoring POSKeyError.
+        if key in self:
+            self.remove(key)
+
+    def pop(self):
+        """Return the popped value.  Raise KeyError if empty."""
+        # Get our iter first to avoid catching and accidentally
+        # ignoring POSKeyError
+        it = iter(self)
+        try:
+            value = next(it)
+        except StopIteration:
+            raise KeyError
+        self.discard(value)
+        return value
+
+    def __ior__(self, it):
+        self.update(it)
+        return self
+
+    def __iand__(self, it):
+        for value in (self - it):
+            self.discard(value)
+        return self
+
+    def __isub__(self, it):
+        if it is self:
+            self.clear()
+        else:
+            for value in it:
+                self.discard(value)
+        return self
+
+    def __ixor__(self, it):
+        if it is self:
+            self.clear()
+        else:
+            for value in it:
+                if value in self:
+                    self.discard(value)
+                else:
+                    self.add(value)
+        return self
+
+
+class Set(_MutableSetMixin, _BucketBase):
 
     __slots__ = ()
 
@@ -789,7 +882,7 @@ class _TreeItem(object):
         self.child = child
 
 
-class _Tree(_Base):
+class _Tree(_ArithmeticMixin, _Base):
 
     __slots__ = ('_data',
                  '_firstbucket',
@@ -1164,15 +1257,6 @@ class _Tree(_Base):
         r = r.replace('Py', '')
         return r
 
-    def __sub__(self, other):
-        return difference(self.__class__, self, other)
-
-    def __or__(self, other):
-        return union(self._set_type, self, other)
-
-    def __and__(self, other):
-        return intersection(self._set_type, self, other)
-
 
 def _get_simple_btree_bucket_state(state):
     if state is None:
@@ -1272,7 +1356,7 @@ class _TreeIterator(object):
         )
 
 
-class Tree(_Tree):
+class Tree(_MutableMappingMixin, _Tree):
 
     __slots__ = ()
 
@@ -1312,7 +1396,7 @@ class Tree(_Tree):
         return bool(self._set(key, value, True)[0])
 
 
-class TreeSet(_Tree):
+class TreeSet(_MutableSetMixin, _Tree):
 
     __slots__ = ()
 

--- a/src/BTrees/_compat.h
+++ b/src/BTrees/_compat.h
@@ -16,6 +16,11 @@
 #undef INT_CHECK
 #endif
 
+#ifndef Py_RETURN_NOTIMPLEMENTED
+#define Py_RETURN_NOTIMPLEMENTED \
+    return Py_INCREF(Py_NotImplemented), Py_NotImplemented
+#endif
+
 #if PY_MAJOR_VERSION >= 3
 
 #define PY3K

--- a/src/BTrees/_compat.py
+++ b/src/BTrees/_compat.py
@@ -62,6 +62,13 @@ else: # pragma: no cover Python3
     def _ascii(x):
         return bytes(x, 'ascii')
 
+try:
+    from collections import abc
+except ImportError:
+    import collections as abc
+
+collections_abc = abc
+del abc
 
 def _c_optimizations_required():
     """

--- a/src/BTrees/tests/common.py
+++ b/src/BTrees/tests/common.py
@@ -468,6 +468,23 @@ class MappingBase(Base): # pylint:disable=too-many-public-methods
         from BTrees._compat import collections_abc
         return collections_abc.MutableMapping
 
+    def test_popitem(self):
+        t = self._makeOne()
+        # Empty
+        with self.assertRaises(KeyError):
+            t.popitem()
+
+        self._populate(t, 2000)
+        self.assertEqual(len(t), 2000)
+        for i in range(2000):
+            self.assertEqual(t.popitem(), (i, i))
+            self.assertEqual(len(t), 2000 - i - 1)
+
+        # Back to empty
+        self.assertEqual(len(t), 0)
+        with self.assertRaises(KeyError):
+            t.popitem()
+
     def testShortRepr(self):
         # test the repr because buckets have a complex repr implementation
         # internally the cutoff from a stack allocated buffer to a heap

--- a/src/BTrees/tests/common.py
+++ b/src/BTrees/tests/common.py
@@ -158,6 +158,43 @@ class Base(ZODBAccess, SignedMixin):
                 if type(seq) not in (tuple, list):
                     verifyObject(IMinimalSequence, seq)
 
+    def _getColectionsABC(self):
+        raise NotImplementedError("subclass should return the collection ABC")
+
+    def testIsinstanceCollectionsABC(self):
+        abc = self._getCollectionsABC()
+        t = self._makeOne()
+
+        self.assertIsInstance(t, abc)
+        # Now make sure that it actually has the required methods.
+        # First, get the required methods:
+        abc_attrs = set(dir(abc))
+        # If the method was None, that means it's not required;
+        # if it's not callable, it's not a method (None is not callable)
+        # If it's a private attribute (starting with only one _), it's
+        # an implementation detail to ignore.
+        abc_attrs -= set(x for x in abc_attrs
+                         if (x[0] == '_' and x[1] != '_')
+                         or not callable(getattr(abc, x, None)))
+        # Drop things from Python typing and zope.interface that may or may not
+        # be present.
+        abc_attrs -= {
+            '__provides__',
+            '__implemented__',
+            '__providedBy__',
+            '__metaclass__', # Python 2.7
+            '__class_getitem__', # Python 3.9
+            # Also the equality and comparison operators;
+            # we don't implement those methods, but the ABC does. On Python
+            # 3, we seem to inherit them from somewhere, but we don't on Python 3
+            '__lt__', '__le__', '__eq__', '__gt__', '__ge__', '__ne__',
+        }
+        btr_attrs = set(dir(type(t)))
+
+        missing_attrs = abc_attrs - btr_attrs
+        self.assertFalse(sorted(missing_attrs),
+                         "Class %r is missing these methods: %s" % (type(t), missing_attrs))
+
     def testPersistentSubclass(self):
         # Can we subclass this and Persistent?
         # https://github.com/zopefoundation/BTrees/issues/78
@@ -426,6 +463,10 @@ class MappingBase(Base): # pylint:disable=too-many-public-methods
         # Make some data
         for i in range(l):
             t[i] = i
+
+    def _getCollectionsABC(self):
+        from BTrees._compat import collections_abc
+        return collections_abc.MutableMapping
 
     def testShortRepr(self):
         # test the repr because buckets have a complex repr implementation
@@ -1740,9 +1781,149 @@ class BTreeTests(MappingBase):
 class NormalSetTests(Base):
     # Test common to all set types
 
+    def _getCollectionsABC(self):
+        from BTrees._compat import collections_abc
+        return collections_abc.MutableSet
+
     def _populate(self, t, l):
         # Make some data
         t.update(range(l))
+
+    def test_isdisjoint(self):
+        t = self._makeOne()
+        # The empty set is disjoint with itself
+        self.assertTrue(t.isdisjoint(t))
+        # Empty sequences
+        self.assertTrue(t.isdisjoint(()))
+        self.assertTrue(t.isdisjoint([]))
+        self.assertTrue(t.isdisjoint(set()))
+        # non-empty sequences but empty set
+        self.assertTrue(t.isdisjoint((1, 2)))
+        self.assertTrue(t.isdisjoint([1, 2]))
+        self.assertTrue(t.isdisjoint(set((1, 2))))
+        self.assertTrue(t.isdisjoint(range(10)))
+
+        # non-empty sequences and non-empty set, null intersection
+        self._populate(t, 2)
+        self.assertEqual(set(t), {0, 1})
+
+        self.assertTrue(t.isdisjoint((2, 3)))
+        self.assertTrue(t.isdisjoint([2, 3]))
+        self.assertTrue(t.isdisjoint(set((2, 3))))
+        self.assertTrue(t.isdisjoint(range(2, 10)))
+
+        # non-null intersection
+        self.assertFalse(t.isdisjoint(t))
+        self.assertFalse(t.isdisjoint((0,)))
+        self.assertFalse(t.isdisjoint((1,)))
+        self.assertFalse(t.isdisjoint([2, 3, 0]))
+        self.assertFalse(t.isdisjoint(set((2, 3, 1))))
+        self.assertFalse(t.isdisjoint(range(1, 10)))
+
+    def test_discard(self):
+        t = self._makeOne()
+        # empty set, raises no error, even if the key is
+        # of the wrong type
+        t.discard(1)
+        t.discard(object())
+        self.assertEqual(set(t), set())
+
+        # non-empty set, discarding absent key
+        self._populate(t, 2)
+        self.assertEqual(set(t), {0, 1})
+        t.discard(3)
+        t.discard(object())
+        self.assertEqual(set(t), {0, 1})
+
+        t.discard(1)
+        self.assertEqual(set(t), {0})
+        t.discard(0)
+        self.assertEqual(set(t), set())
+
+    def test_pop(self):
+        t = self._makeOne()
+        with self.assertRaises(KeyError):
+            t.pop()
+
+        self._populate(t, 2)
+        self.assertEqual(0, t.pop())
+        self.assertEqual(1, t.pop())
+        self.assertEqual(set(t), set())
+        with self.assertRaises(KeyError):
+            t.pop()
+
+    def test___ior__(self):
+        t = self._makeOne()
+        orig_t = t
+        t |= (1,)
+        t |= [2,]
+        t |= {1, 2, 3}
+        t |= range(10)
+        t |= t
+        self.assertIs(t, orig_t)
+        self.assertEqual(set(t), set(range(10)))
+
+    def test___iand__(self):
+        t = self._makeOne()
+        orig_t = t
+        t &= (1,)
+        t &= [2,]
+        t &= {3, 4}
+        self.assertIs(t, orig_t)
+        self.assertEqual(set(t), set())
+
+        self._populate(t, 10)
+        self.assertEqual(set(t), set(range(10)))
+
+        t &= (1, 2, 3)
+        self.assertIs(t, orig_t)
+        self.assertEqual(set(t), {1, 2, 3})
+
+    def test___isub__(self):
+        t = self._makeOne()
+        orig_t = t
+        t -= (1,)
+        t -= [2,]
+        t -= {3, 4}
+        self.assertIs(t, orig_t)
+        self.assertEqual(set(t), set())
+
+        self._populate(t, 10)
+        self.assertEqual(set(t), set(range(10)))
+
+        t -= (1, 2, 3)
+        self.assertIs(t, orig_t)
+        self.assertEqual(set(t), {0, 4, 5, 6, 7, 8, 9})
+
+        t -= t
+        self.assertIs(t, orig_t)
+        self.assertEqual(set(t), set())
+
+    def test___ixor__(self):
+        t = self._makeOne()
+        orig_t = t
+        t ^= (1,)
+        self.assertEqual(set(t), {1,})
+        t ^= t
+        self.assertEqual(set(t), set())
+
+        t ^= (1, 2, 3)
+        self.assertEqual(set(t), {1, 2, 3})
+        t ^= [2, 3, 4]
+        self.assertEqual(set(t), {1, 4})
+
+    def test___xor__(self):
+        t = self._makeOne()
+        u = t ^ (1,)
+        self.assertEqual(set(u), {1,})
+        u = t ^ t
+        self.assertEqual(set(u), set())
+
+        u = t ^ (1, 2, 3)
+        self.assertEqual(set(u), {1, 2, 3})
+        t.update(u)
+        u = t ^ [2, 3, 4]
+        self.assertEqual(set(u), {1, 4})
 
     def testShortRepr(self):
         t = self._makeOne()


### PR DESCRIPTION
Add tests to verify they implement the required methods. Turns out they didn't, so implement them.
This means `popitem` for the mappings, and `pop/discard/isdisjoint` plus a swath of operators for the sets.

Do this in both C and Python. The implementations are probably on the naive side, in that they work with generic iterators and don't try to do any complex structural merging, but that makes them easier to understand and hopefully be correct. Performance shouldn't be too bad, nothing worse than `O(N*logM)` (roughly). The `__iand__` method requires extra storage space of up to `O(N)`, and `__xor__` requires storage of O(N*M).

Fixes #121

This was a lot bigger than I expected.