### PR TITLE
Disable unsafe-math-optimizations in CFLAGS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,8 +61,8 @@ env:
   PIP_NO_PYTHON_VERSION_WARNING: 1
   PIP_NO_WARN_SCRIPT_LOCATION: 1
 
-  CFLAGS: -Ofast -pipe
-  CXXFLAGS: -Ofast -pipe
+  CFLAGS: -Ofast -pipe -fno-unsafe-math-optimizations
+  CXXFLAGS: -Ofast -pipe -fno-unsafe-math-optimizations
   # Uploading built wheels for releases.
   # TWINE_PASSWORD is encrypted and stored directly in the
   # github repo settings.

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -31,7 +31,7 @@ if [ `uname -m` == 'aarch64' ]; then
     export CFLAGS="-O1 $CFLAGS"
 else
     echo "Compiling with -Ofast"
-    export CFLAGS="-Ofast $CFLAGS"
+    export CFLAGS="-Ofast -fno-unsafe-math-optimizations $CFLAGS"
 fi
 
 export PURE_PYTHON=0

--- a/.meta.toml
+++ b/.meta.toml
@@ -74,7 +74,7 @@ manylinux-install-setup = [
     "    export CFLAGS=\"-O1 $CFLAGS\"",
     "else",
     "    echo \"Compiling with -Ofast\"",
-    "    export CFLAGS=\"-Ofast $CFLAGS\"",
+    "    export CFLAGS=\"-Ofast -fno-unsafe-math-optimizations $CFLAGS\"",
     "fi",
     "",
     "export PURE_PYTHON=0",


### PR DESCRIPTION
Current binary wheels use `-Ofast` optimization option, which (apart from other things) enables flush-to-zero (FTZ) behavior for IEEE-754 subnormals. Unfortunately, FTZ is a global CPU flag, so it affect other running code. Let me add some specific examples:

NumPy emits UserWarning: https://github.com/numpy/numpy/blob/main/numpy/core/getlimits.py#L80

Hypothesis fails on import: https://github.com/HypothesisWorks/hypothesis/blob/master/hypothesis-python/src/hypothesis/strategies/_internal/numbers.py#L211

I have added `-fno-unsafe-math-optimizations` option to manylinux build `CFLAGS`, which disables this kind of standard-violating optimization.