### PR TITLE
Fix GHA-Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -205,10 +205,7 @@ jobs:
           python setup.py bdist_wheel
 
       - name: Install BTrees and dependencies
-        run: |
-          # Install to collect dependencies into the (pip) cache.
-          pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
-          pip install .[test]
+        run: pip install .[test]
 
       - name: Check BTrees build
         run: |
@@ -318,7 +315,6 @@ jobs:
         run: |
           pip install -U wheel setuptools
           pip install -U coverage
-          pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
           pip install -U 'cffi; platform_python_implementation == "CPython"'
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "342271a70d886e753e5cc629e8a81b3cfab692ac"
+commit-id = "d6240444ec6c9e203f2fd9f62c3e6038f9189e96"
 
 [python]
 with-appveyor = true
@@ -35,6 +35,9 @@ testenv-additional = [
     "[testenv:w_zodb-pure]",
     "basepython = python3.9",
     "deps = ZODB",
+    ]
+testenv-deps = [
+    "zope.testrunner",
     ]
 
 [coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ envlist =
 [testenv]
 usedevelop = true
 deps =
+    zope.testrunner
 setenv =
     pure: PURE_PYTHON=1
     !pure-!pypy-!pypy3: PURE_PYTHON=0
@@ -50,6 +51,7 @@ allowlist_externals =
     mkdir
 deps =
     coverage
+    zope.testrunner
 setenv =
     PURE_PYTHON=1
 commands =


### PR DESCRIPTION
Try out omitting to install faulthandler.
The repository was archived and the packages was deleted from PyPI 😭 
See https://github.com/vstinner/faulthandler