### PR TITLE
Preliminary support for Python 3.13a3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,7 +128,7 @@ jobs:
           echo "dir=$(pip cache dir)" >>$GITHUB_OUTPUT
 
       - name: pip cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}
@@ -142,7 +142,8 @@ jobs:
           pip install -U setuptools wheel twine
           # cffi will probably have no public release until a Python 3.13 beta
           # or even RC release, see https://github.com/python-cffi/cffi/issues/23
-          pip install -U "cffi @ https://github.com/python-cffi/cffi/archive/refs/heads/main.zip"
+          echo "cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58" > cffi_constraint.txt
+          PIP_CONSTRAINT=cffi_constraint.txt pip install cffi
           # twine has no release for 3.13, yet, see https://github.com/pypa/twine/issues/1030
           pip install -U "git+https://github.com/pypa/twine.git#egg=twine"
       - name: Install Build Dependencies
@@ -195,9 +196,12 @@ jobs:
         if: matrix.python-version == '3.13.0-alpha - 3.13.0'
         run: |
           # Install to collect dependencies into the (pip) cache.
+          # cffi will probably have no public release until a Python 3.13 beta
+          # or even RC release, see https://github.com/python-cffi/cffi/issues/23
+          echo "cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58" > cffi_constraint.txt
           # Use "--pre" here because dependencies with support for this future
           # Python release may only be available as pre-releases
-          pip install --pre .[test]
+          PIP_CONSTRAINT=cffi_constraint.txt pip install --pre .[test]
       - name: Install BTrees and dependencies
         if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
@@ -288,7 +292,7 @@ jobs:
           echo "dir=$(pip cache dir)" >>$GITHUB_OUTPUT
 
       - name: pip cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}
@@ -306,17 +310,17 @@ jobs:
           pip install -U wheel setuptools
           # cffi will probably have no public release until a beta or even RC
           # version of Python 3.13, see https://github.com/python-cffi/cffi/issues/23
-          pip install -U 'cffi @ https://github.com/python-cffi/cffi/archive/refs/heads/main.zip ; platform_python_implementation == "CPython"'
+          echo 'cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58 ; platform_python_implementation == "CPython"' > cffi_constraint.txt
           # coverage has a wheel on PyPI for a future python version which is
           # not ABI compatible with the current one, so build it from sdist:
           pip install -U --no-binary :all: coverage
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This
           # might also save some build time?
-          unzip -n dist/BTrees-*whl -d src
+          unzip -n dist/zope.index-*whl -d src
           # Use "--pre" here because dependencies with support for this future
           # Python release may only be available as pre-releases
-          pip install --pre -U -e .[test]
+          PIP_CONSTRAINT=cffi_constraint.txt pip install --pre -U -e .[test]
       - name: Install BTrees
         if: ${{ !startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0') }}
         run: |
@@ -383,7 +387,7 @@ jobs:
           echo "dir=$(pip cache dir)" >>$GITHUB_OUTPUT
 
       - name: pip cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}
@@ -434,7 +438,7 @@ jobs:
           echo "dir=$(pip cache dir)" >>$GITHUB_OUTPUT
 
       - name: pip cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}
@@ -487,7 +491,7 @@ jobs:
           echo "dir=$(pip cache dir)" >>$GITHUB_OUTPUT
 
       - name: pip cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip_manylinux-${{ matrix.image }}-${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -317,7 +317,7 @@ jobs:
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This
           # might also save some build time?
-          unzip -n dist/zope.index-*whl -d src
+          unzip -n dist/BTrees-*whl -d src
           # Use "--pre" here because dependencies with support for this future
           # Python release may only be available as pre-releases
           PIP_CONSTRAINT=cffi_constraint.txt pip install --pre -U -e .[test]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,23 +96,24 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "pypy-3.9"
+          - "pypy-3.10"
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13.0-alpha - 3.13.0"
         os: [ubuntu-20.04, macos-11]
         exclude:
           - os: macos-11
-            python-version: "pypy-3.9"
+            python-version: "pypy-3.10"
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       ###
@@ -134,7 +135,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
+      - name: Install Build Dependencies (3.13.0-alpha - 3.13.0)
+        if: matrix.python-version == '3.13.0-alpha - 3.13.0'
+        run: |
+          pip install -U pip
+          pip install -U setuptools wheel twine
+          # cffi will probably have no public release until a Python 3.13 beta
+          # or even RC release, see https://github.com/python-cffi/cffi/issues/23
+          pip install -U "cffi @ https://github.com/python-cffi/cffi/archive/refs/heads/main.zip"
+          # twine has no release for 3.13, yet, see https://github.com/pypa/twine/issues/1030
+          pip install -U "git+https://github.com/pypa/twine.git#egg=twine"
       - name: Install Build Dependencies
+        if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine cffi
@@ -179,7 +191,15 @@ jobs:
           python setup.py build_ext -i
           python setup.py bdist_wheel
 
+      - name: Install BTrees and dependencies (3.13.0-alpha - 3.13.0)
+        if: matrix.python-version == '3.13.0-alpha - 3.13.0'
+        run: |
+          # Install to collect dependencies into the (pip) cache.
+          # Use "--pre" here because dependencies with support for this future
+          # Python release may only be available as pre-releases
+          pip install --pre .[test]
       - name: Install BTrees and dependencies
+        if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
           # Install to collect dependencies into the (pip) cache.
           pip install .[test]
@@ -191,7 +211,7 @@ jobs:
       - name: Upload BTrees wheel (macOS x86_64)
         if: >
           startsWith(runner.os, 'Mac')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: BTrees-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/*x86_64.whl
@@ -200,7 +220,7 @@ jobs:
           startsWith(runner.os, 'Mac')
           && !(startsWith(matrix.python-version, 'pypy')
                || matrix.python-version == '3.7')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           # The arm64 wheel is uploaded with a different name just so it can be
           # manually downloaded when desired. The wheel itself *cannot* be tested
@@ -210,7 +230,7 @@ jobs:
       - name: Upload BTrees wheel (all other platforms)
         if: >
           !startsWith(runner.os, 'Mac')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: BTrees-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/*whl
@@ -223,6 +243,7 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
+          && !startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -235,23 +256,24 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "pypy-3.9"
+          - "pypy-3.10"
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13.0-alpha - 3.13.0"
         os: [ubuntu-20.04, macos-11]
         exclude:
           - os: macos-11
-            python-version: "pypy-3.9"
+            python-version: "pypy-3.10"
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       ###
@@ -274,11 +296,29 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Download BTrees wheel
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: BTrees-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
+      - name: Install BTrees 3.13.0-alpha - 3.13.0
+        if: ${{ startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0') }}
+        run: |
+          pip install -U wheel setuptools
+          # cffi will probably have no public release until a beta or even RC
+          # version of Python 3.13, see https://github.com/python-cffi/cffi/issues/23
+          pip install -U 'cffi @ https://github.com/python-cffi/cffi/archive/refs/heads/main.zip ; platform_python_implementation == "CPython"'
+          # coverage has a wheel on PyPI for a future python version which is
+          # not ABI compatible with the current one, so build it from sdist:
+          pip install -U --no-binary :all: coverage
+          # Unzip into src/ so that testrunner can find the .so files
+          # when we ask it to load tests from that directory. This
+          # might also save some build time?
+          unzip -n dist/BTrees-*whl -d src
+          # Use "--pre" here because dependencies with support for this future
+          # Python release may only be available as pre-releases
+          pip install --pre -U -e .[test]
       - name: Install BTrees
+        if: ${{ !startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0') }}
         run: |
           pip install -U wheel setuptools
           pip install -U coverage
@@ -326,9 +366,9 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       ###
@@ -351,7 +391,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Download BTrees wheel
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: BTrees-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
@@ -377,9 +417,9 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       ###
@@ -402,7 +442,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Download BTrees wheel
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: BTrees-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
@@ -430,9 +470,9 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       ###
@@ -482,7 +522,7 @@ jobs:
           bash .manylinux.sh
 
       - name: Upload BTrees wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/*whl
           name: manylinux_${{ matrix.image }}_wheels.zip

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -40,6 +40,7 @@ yum -y install libffi-devel
 
 tox_env_map() {
     case $1 in
+        *"cp313"*) echo 'py313';;
         *"cp37"*) echo 'py37';;
         *"cp38"*) echo 'py38';;
         *"cp39"*) echo 'py39';;
@@ -53,14 +54,20 @@ tox_env_map() {
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     if \
+       [[ "${PYBIN}" == *"cp313"* ]] || \
        [[ "${PYBIN}" == *"cp311"* ]] || \
        [[ "${PYBIN}" == *"cp312"* ]] || \
        [[ "${PYBIN}" == *"cp37"* ]] || \
        [[ "${PYBIN}" == *"cp38"* ]] || \
        [[ "${PYBIN}" == *"cp39"* ]] || \
        [[ "${PYBIN}" == *"cp310"* ]] ; then
-        "${PYBIN}/pip" install -e /io/
-        "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+        if [[ "${PYBIN}" == *"cp313"* ]] ; then
+            "${PYBIN}/pip" install --pre -e /io/
+            "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
+        else
+            "${PYBIN}/pip" install -e /io/
+            "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+        fi
         if [ `uname -m` == 'aarch64' ]; then
           # Running the test suite takes forever in
           # emulation; an early run (using tox, which is also slow)

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "a361e1fd"
+commit-id = "e45966cd"
 
 [python]
 with-appveyor = true

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "e45966cd"
+commit-id = "d3005188"
 
 [python]
 with-appveyor = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
 5.1.1 (unreleased)
 ==================
 
+- Add preliminary support for Python 3.13 as of 3.13a3.
 
 5.1 (2023-10-05)
 ================

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,9 @@ environment:
     - python: 310-x64
     - python: 311-x64
     - python: 312-x64
+    # `multibuild` cannot install non-final versions as they are not on
+    # ftp.python.org, so we skip Python 3.13 until its final release:
+    # - python: 313-x64
 
 install:
   - "SET PYTHONVERSION=%PYTHON%"

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
     py310,py310-pure
     py311,py311-pure
     py312,py312-pure
+    py313,py313-pure
     pypy3
     docs
     coverage
@@ -18,7 +19,9 @@ envlist =
 
 [testenv]
 usedevelop = true
+pip_pre = py313: true
 deps =
+    Sphinx
 setenv =
     pure: PURE_PYTHON=1
     !pure-!pypy3: PURE_PYTHON=0
@@ -56,17 +59,39 @@ commands =
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}
     coverage html -i
     coverage report -i -m --fail-under=93
+[testenv:release-check]
+description = ensure that the distribution is ready to release
+basepython = python3
+skip_install = true
+deps =
+    twine
+    build
+    check-manifest
+    check-python-versions >= 0.20.0
+    wheel
+commands_pre =
+commands =
+    check-manifest
+    check-python-versions
+    python -m build --sdist --no-isolation
+    twine check dist/*
 
 [testenv:lint]
 basepython = python3
 skip_install = true
-commands =
-    check-manifest
-    check-python-versions
 deps =
-    check-manifest
-    check-python-versions >= 0.19.1
-    wheel
+    isort
+commands =
+    isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py
+
+[testenv:isort-apply]
+basepython = python3
+skip_install = true
+commands_pre =
+deps =
+    isort
+commands =
+    isort {toxinidir}/src {toxinidir}/setup.py []
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
open issues:

- [x] *WARN* `Py_FileSystemDefaultEncoding` has been explicitly marked deprecated in 3.12 in `_cffi_backend.c`
- [x] *ERR* `_PyErr_WriteUnraisableMsg` is undefined in `_cffi_backend.c`