### PR TITLE
Remove preliminary support for Python 3.13 as it is not yet ready.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,7 +103,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - "3.13.0-alpha - 3.13.0"
         os: [ubuntu-20.04, macos-11]
         exclude:
           - os: macos-11
@@ -135,19 +134,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - name: Install Build Dependencies (3.13.0-alpha - 3.13.0)
-        if: matrix.python-version == '3.13.0-alpha - 3.13.0'
-        run: |
-          pip install -U pip
-          pip install -U setuptools wheel twine
-          # cffi will probably have no public release until a Python 3.13 beta
-          # or even RC release, see https://github.com/python-cffi/cffi/issues/23
-          echo "cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58" > cffi_constraint.txt
-          PIP_CONSTRAINT=cffi_constraint.txt pip install cffi
-          # twine has no release for 3.13, yet, see https://github.com/pypa/twine/issues/1030
-          pip install -U "git+https://github.com/pypa/twine.git#egg=twine"
       - name: Install Build Dependencies
-        if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine cffi
@@ -192,18 +179,7 @@ jobs:
           python setup.py build_ext -i
           python setup.py bdist_wheel
 
-      - name: Install BTrees and dependencies (3.13.0-alpha - 3.13.0)
-        if: matrix.python-version == '3.13.0-alpha - 3.13.0'
-        run: |
-          # Install to collect dependencies into the (pip) cache.
-          # cffi will probably have no public release until a Python 3.13 beta
-          # or even RC release, see https://github.com/python-cffi/cffi/issues/23
-          echo "cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58" > cffi_constraint.txt
-          # Use "--pre" here because dependencies with support for this future
-          # Python release may only be available as pre-releases
-          PIP_CONSTRAINT=cffi_constraint.txt pip install --pre .[test]
       - name: Install BTrees and dependencies
-        if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
           # Install to collect dependencies into the (pip) cache.
           pip install .[test]
@@ -247,7 +223,6 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
-          && !startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -267,7 +242,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - "3.13.0-alpha - 3.13.0"
         os: [ubuntu-20.04, macos-11]
         exclude:
           - os: macos-11
@@ -304,25 +278,7 @@ jobs:
         with:
           name: BTrees-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
-      - name: Install BTrees 3.13.0-alpha - 3.13.0
-        if: ${{ startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0') }}
-        run: |
-          pip install -U wheel setuptools
-          # cffi will probably have no public release until a beta or even RC
-          # version of Python 3.13, see https://github.com/python-cffi/cffi/issues/23
-          echo 'cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58 ; platform_python_implementation == "CPython"' > cffi_constraint.txt
-          # coverage has a wheel on PyPI for a future python version which is
-          # not ABI compatible with the current one, so build it from sdist:
-          pip install -U --no-binary :all: coverage
-          # Unzip into src/ so that testrunner can find the .so files
-          # when we ask it to load tests from that directory. This
-          # might also save some build time?
-          unzip -n dist/BTrees-*whl -d src
-          # Use "--pre" here because dependencies with support for this future
-          # Python release may only be available as pre-releases
-          PIP_CONSTRAINT=cffi_constraint.txt pip install --pre -U -e .[test]
       - name: Install BTrees
-        if: ${{ !startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0') }}
         run: |
           pip install -U wheel setuptools
           pip install -U coverage

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -40,7 +40,6 @@ yum -y install libffi-devel
 
 tox_env_map() {
     case $1 in
-        *"cp313"*) echo 'py313';;
         *"cp37"*) echo 'py37';;
         *"cp38"*) echo 'py38';;
         *"cp39"*) echo 'py39';;
@@ -54,20 +53,14 @@ tox_env_map() {
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     if \
-       [[ "${PYBIN}" == *"cp313"* ]] || \
        [[ "${PYBIN}" == *"cp311"* ]] || \
        [[ "${PYBIN}" == *"cp312"* ]] || \
        [[ "${PYBIN}" == *"cp37"* ]] || \
        [[ "${PYBIN}" == *"cp38"* ]] || \
        [[ "${PYBIN}" == *"cp39"* ]] || \
        [[ "${PYBIN}" == *"cp310"* ]] ; then
-        if [[ "${PYBIN}" == *"cp313"* ]] ; then
-            "${PYBIN}/pip" install --pre -e /io/
-            "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
-        else
-            "${PYBIN}/pip" install -e /io/
-            "${PYBIN}/pip" wheel /io/ -w wheelhouse/
-        fi
+        "${PYBIN}/pip" install -e /io/
+        "${PYBIN}/pip" wheel /io/ -w wheelhouse/
         if [ `uname -m` == 'aarch64' ]; then
           # Running the test suite takes forever in
           # emulation; an early run (using tox, which is also slow)

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,13 +2,13 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "d3005188"
+commit-id = "1351c95d"
 
 [python]
 with-appveyor = true
 with-windows = false
 with-pypy = true
-with-future-python = true
+with-future-python = false
 with-docs = true
 with-sphinx-doctests = true
 with-macos = false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,9 +15,6 @@ environment:
     - python: 310-x64
     - python: 311-x64
     - python: 312-x64
-    # `multibuild` cannot install non-final versions as they are not on
-    # ftp.python.org, so we skip Python 3.13 until its final release:
-    # - python: 313-x64
 
 install:
   - "SET PYTHONVERSION=%PYTHON%"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,5 @@
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
-[bdist_wheel]
-universal = 0
 
 [zest.releaser]
 create-wheel = no

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ envlist =
     py310,py310-pure
     py311,py311-pure
     py312,py312-pure
-    py313,py313-pure
     pypy3
     docs
     coverage
@@ -19,9 +18,7 @@ envlist =
 
 [testenv]
 usedevelop = true
-pip_pre = py313: true
 deps =
-    Sphinx
 setenv =
     pure: PURE_PYTHON=1
     !pure-!pypy3: PURE_PYTHON=0
@@ -72,7 +69,7 @@ deps =
 commands_pre =
 commands =
     check-manifest
-    check-python-versions
+    check-python-versions --only setup.py,tox.ini,.github/workflows/tests.yml
     python -m build --sdist --no-isolation
     twine check dist/*
 


### PR DESCRIPTION
This is needed to make tests on `master` green again, until we found a solution for #197 